### PR TITLE
exchange boto3 module with custom requests_auth implementation

### DIFF
--- a/otcextensions/sdk/ak_auth.py
+++ b/otcextensions/sdk/ak_auth.py
@@ -54,8 +54,6 @@ except ImportError:
         return s
 
 
-# from keystoneauth1 import plugin
-
 EMPTY_SHA256_HASH = (
     'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
 
@@ -70,26 +68,6 @@ SIGNED_HEADERS_BLACKLIST = [
 ]
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 SIGV4_TIMESTAMP = '%Y%m%dT%H%M%SZ'
-
-
-def sign(key, msg):
-    """
-    Copied from
-        https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
-    """
-    return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
-
-
-def getSignatureKey(key, dateStamp, regionName, serviceName):
-    """
-    Copied from
-        https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
-    """
-    kDate = sign(('AWS4' + key).encode('utf-8'), dateStamp)
-    kRegion = sign(kDate, regionName)
-    kService = sign(kRegion, serviceName)
-    kSigning = sign(kService, 'aws4_request')
-    return kSigning
 
 
 class AKRequestsAuth(requests.auth.AuthBase):
@@ -126,15 +104,6 @@ class AKRequestsAuth(requests.auth.AuthBase):
         self.service = service
         self.aws_token = token
 
-        # self.auth = auth.S3SigV4QueryAuth(
-        #     credentials={
-        #         'access_key': access_key,
-        #         'secret_key': secret_access_key,
-        #     },
-        #     region_name=aws_region,
-        #     service_name=aws_service,
-        # )
-
     def __call__(self, r):
         """
         Adds the authorization headers required by Amazon's signature
@@ -142,174 +111,8 @@ class AKRequestsAuth(requests.auth.AuthBase):
         Adapted from
             https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
         """
-        print('auth is invoked')
         self.add_auth(r)
-        print('auth result %s' % r.headers)
-        # aws_headers = self.get_aws_request_headers_handler(r)
-        # r.headers.update(aws_headers)
-        # r.headers.pop('X-Auth-Token')
-        # print('result request is %s' % r.headers)
         return r
-
-    # def get_token(self, session, **kwargs):
-    #     print('get token is called')
-    #     return 'some crap'
-
-    # def get_endpoint(self, session, **kwargs):
-    #     return self.aws_host
-    #
-    # def get_endpoint_data(self, session,
-    #                       endpoint_override=None,
-    #                       discover_versions=False,
-    #                       **kwargs):
-    #     """Return a valid endpoint data for a the service.
-    #     :param session: A session object that can be used for communication.
-    #     :type session: keystoneauth1.session.Session
-    #     :param str endpoint_override: URL to use for version discovery.
-    #     :param bool discover_versions: Whether to get version metadata from
-    #                                    the version discovery document even
-    #                                    if it major api version info can be
-    #                                    inferred from the url.
-    #                                    (optional, defaults to True)
-    #     :param kwargs: Ignored.
-    #     :raises keystoneauth1.exceptions.http.HttpError: An error from an
-#                                                      invalid HTTP response.
-    #     :return: Valid EndpointData or None if not available.
-    #     :rtype: `keystoneauth1.discover.EndpointData` or None
-    #     """
-    #     return None
-    #     if not endpoint_override:
-    #         return None
-    #     endpoint_data = discover.EndpointData(catalog_url=endpoint_override)
-    #
-    #     if endpoint_data.api_version and not discover_versions:
-    #         return endpoint_data
-    #
-    #     return endpoint_data.get_versioned_data(
-    #         session, cache=self._discovery_cache,
-    #         discover_versions=discover_versions)
-
-    def get_aws_request_headers_handler(self, r):
-        """
-        Override get_aws_request_headers_handler() if you have a
-        subclass that needs to call get_aws_request_headers() with
-        an arbitrary set of AWS credentials. The default implementation
-        calls get_aws_request_headers() with self.aws_access_key,
-        self.aws_secret_access_key, and self.aws_token
-        """
-        return self.get_aws_request_headers(
-            r=r,
-            aws_access_key=self.aws_access_key,
-            aws_secret_access_key=self.aws_secret_access_key,
-            aws_token=self.aws_token)
-
-    def get_aws_request_headers(
-            self, r, aws_access_key, aws_secret_access_key, aws_token):
-        """
-        Returns a dictionary containing the necessary headers for Amazon's
-        signature version 4 signing process. An example return value might
-        look like
-            {
-                'Authorization': 'AWS4-HMAC-SHA256 Credential=YOURKEY/'
-                                 '20160618/us-east-1/es/aws4_request, '
-                                 'SignedHeaders=host;x-amz-date, '
-                                 'Signature=ca0a856286efce2a4bd96a978ca6c8966057e53184776c0685169d08abd74739',
-                'x-amz-date': '20160618T220405Z',
-            }
-        """
-        # Create a date for headers and the credential string
-        t = datetime.datetime.utcnow()
-        amzdate = t.strftime('%Y%m%dT%H%M%SZ')
-        datestamp = t.strftime('%Y%m%d')  # Date w/o time for credential_scope
-
-        canonical_uri = AKRequestsAuth.get_canonical_path(r)
-
-        canonical_querystring = AKRequestsAuth.get_canonical_querystring(r)
-
-        # Create payload hash (hash of the request body content). For GET
-        # requests, the payload is an empty string ('').
-        body = r.body if r.body else bytes()
-        try:
-            body = body.encode('utf-8')
-        except (AttributeError, UnicodeDecodeError):
-            # On py2, if unicode characters in present in `body`,
-            # encode() throws UnicodeDecodeError, but we can safely
-            # pass unencoded `body` to execute hexdigest().
-            #
-            # For py3, encode() will execute successfully regardless
-            # of the presence of unicode data
-            body = body
-
-        payload_hash = hashlib.sha256(body).hexdigest()
-
-        # Create the canonical headers and signed headers. Header names
-        # and value must be trimmed and lowercase, and sorted in ASCII order.
-        # Note that there is a trailing \n.
-        canonical_headers = ('host:' + self.aws_host + '\n' +
-                             'x-amz-date:' + amzdate + '\n' +
-                             'x-amz-content-sha256:' + EMPTY_SHA256_HASH +
-                             '\n')
-        if aws_token:
-            canonical_headers += 'x-amz-security-token:' + aws_token + '\n'
-
-        # Create the list of signed headers. This lists the headers
-        # in the canonical_headers list, delimited with ";" and in alpha order.
-        # Note: The request can include any headers; canonical_headers and
-        # signed_headers lists those that you want to be included in the
-        # hash of the request. "Host" and "x-amz-date" are always required.
-        signed_headers = 'host;x-amz-date;x-amz-content-sha256'
-        if aws_token:
-            signed_headers += ';x-amz-security-token'
-
-        # Combine elements to create create canonical request
-        canonical_request = (r.method + '\n' + canonical_uri + '\n' +
-                             canonical_querystring + '\n' + canonical_headers +
-                             '\n' + signed_headers + '\n' + payload_hash)
-
-        # Match the algorithm to the hashing algorithm you use, either SHA-1 or
-        # SHA-256 (recommended)
-        algorithm = 'AWS4-HMAC-SHA256'
-        credential_scope = (datestamp + '/' + self.aws_region + '/' +
-                            self.service + '/' + 'aws4_request')
-        string_to_sign = (
-            algorithm + '\n' +
-            amzdate + '\n' +
-            credential_scope + '\n' +
-            hashlib.sha256(canonical_request.encode('utf-8')).hexdigest())
-
-        print('')
-        print('can_req=%s' % canonical_request)
-        print('string to sign=%s' % string_to_sign)
-        print('')
-        # Create the signing key using the function defined above.
-        signing_key = getSignatureKey(aws_secret_access_key,
-                                      datestamp,
-                                      self.aws_region,
-                                      self.service)
-
-        # Sign the string_to_sign using the signing_key
-        string_to_sign_utf8 = string_to_sign.encode('utf-8')
-        signature = hmac.new(signing_key,
-                             string_to_sign_utf8,
-                             hashlib.sha256).hexdigest()
-
-        # The signing information can be either in a query string value or in
-        # a header named Authorization. This code shows how to use a header.
-        # Create authorization header and add to request headers
-        authorization_header = (
-            algorithm + ' ' +
-            'Credential=' + aws_access_key + '/' + credential_scope + ', ' +
-            'SignedHeaders=' + signed_headers + ', ' +
-            'Signature=' + signature)
-
-        headers = {
-            'Authorization': authorization_header,
-            'x-amz-date': amzdate,
-            'x-amz-content-sha256': EMPTY_SHA256_HASH,
-        }
-        if aws_token:
-            headers['X-Amz-Security-Token'] = aws_token
-        return headers
 
     def add_auth(self, request):
         """

--- a/otcextensions/sdk/obs/v1/_base.py
+++ b/otcextensions/sdk/obs/v1/_base.py
@@ -9,16 +9,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-# from xml.etree import ElementTree
-import boto3
-
-from botocore.exceptions import ClientError
 
 from openstack import _log
-from openstack import exceptions
 
-from otcextensions.i18n import _
-from otcextensions.sdk import ak_auth
+from collections import defaultdict
+
 from otcextensions.sdk import sdk_resource
 from otcextensions.sdk.obs import obs_service
 
@@ -27,268 +22,31 @@ _logger = _log.setup_logging('openstack')
 
 
 class BaseResource(sdk_resource.Resource):
-    SESSION_ATTR_NAME = '_boto_session'
     service = obs_service.ObsService()
+    OBS_NS = "http://obs.otc.t-systems.com/doc/2016-01-01/"
 
     @classmethod
-    def _get_endpoint(cls, session):
-        """Return a proper endpoint
-
+    def etree_to_dict(cls, t):
+        """Convert ETree to python dict
         """
-        session = cls._get_session(session)
-        region = getattr(session, 'region_name', None)
-        endpoint = session.get_endpoint(
-            service_type='object',
-            service_name='objectstorage',
-            region_name=region)
-
-        if not endpoint:
-            raise exceptions.SDKException(
-                _('Can\'t get endpoint from the catalogue for the '
-                  'service_type = %(type)s, service_name = %(name)s') %
-                {'type': 'object', 'name': 'objectstoage'}
-            )
-        else:
-            _logger.debug('endpoint for OBS is %s' % endpoint)
-
-        return endpoint
-
-    @classmethod
-    def _establish_session(cls, session):
-        """Establish BOTO3 (AWS) session to the server
-
-        """
-        _logger.debug('establishing session')
-        region = getattr(session, 'region_name', None)
-        ak = getattr(session, 'AK', None)
-        sk = getattr(session, 'SK', None)
-        endpoint = cls._get_endpoint(session)
-
-        # if not region:
-        #     _logger.debug('region is not set in the connection. '
-        #                   'Default is used')
-        if ak and sk:
-            _logger.debug('SK/AK available, establish connection')
-            otcsession = boto3.session.Session()
-
-            s3client = otcsession.client(
-                's3',
-                region,
-                # config=boto3.session.Config(signature_version='s3v4'),
-                endpoint_url=endpoint,
-                aws_access_key_id=ak,
-                aws_secret_access_key=sk
-            )
-            setattr(session, BaseResource.SESSION_ATTR_NAME, s3client)
-            return s3client
-        else:
-            _logger.error('Some of AK/SK/Region is not set, abort')
-            return False
-
-    @classmethod
-    def _get_req_auth(cls, session):
-        auth = getattr(session, '_ak_auth', None)
-        if not auth:
-            region = getattr(session, 'region_name', None)
-            ak = getattr(session, 'AK', None)
-            sk = getattr(session, 'SK', None)
-            endpoint = cls._get_endpoint(session)
-
-            auth = ak_auth.AKRequestsAuth(
-                access_key=ak,
-                secret_access_key=sk,
-                host=endpoint,
-                region=region,
-                service='s3'
-            )
-            setattr(session, '_ak_auth', auth)
-        return auth
-
-    @classmethod
-    def _get_boto_session(cls, session):
-        """Retrieve internal session
-
-        """
-        s3session = getattr(session, BaseResource.SESSION_ATTR_NAME, None)
-        if not s3session:
-            s3session = cls._establish_session(session)
-        return s3session
-
-    def _create(self, session, remote_method, prepend_key=True):
-        """Create a remote resource based on this instance.
-
-        :param session: The session to use for making this request.
-        :type session: :class:`~keystoneauth1.adapter.Adapter`
-        :param prepend_key: A boolean indicating whether the resource_key
-                            should be prepended in a resource creation
-                            request. Default to True.
-
-        :return: This :class:`Resource` instance.
-        :raises: :exc:`~openstack.exceptions.MethodNotSupported` if
-                 :data:`Resource.allow_create` is not set to ``True``.
-        """
-        request = self._prepare_request(
-            requires_id=True, prepend_key=prepend_key)
-
-        session = self._get_boto_session(session)
-        response = None
-        try:
-            func = getattr(session, remote_method)
-            response = func(**request.body)
-        except ClientError as e:
-            raise exceptions.SDKException(_('Exception %s') % str(e))
-
-        self._translate_response(response, has_body=False)
-        return self
-
-    def delete(self, session, remote_method, error_message=None):
-        """Delete the remote resource based on this instance.
-
-        This function overrides default Resource.delete to enable headers
-
-        :param session: The session to use for making this request.
-        :type session: :class:`~keystoneauth1.adapter.Adapter`
-
-        :return: This :class:`Resource` instance.
-        :raises: :exc:`~openstack.exceptions.MethodNotSupported` if
-                 :data:`Resource.allow_update` is not set to ``True``.
-        """
-        if not self.allow_delete:
-            raise exceptions.MethodNotSupported(self, "delete")
-
-        request = self._prepare_request()
-        session = self._get_boto_session(session)
-
-        response = None
-        try:
-            func = getattr(session, remote_method)
-            response = func(**request.body)
-        except ClientError as e:
-            raise exceptions.SDKException(_('Exception %s') % str(e))
-
-        kwargs = {}
-        if error_message:
-            kwargs['error_message'] = error_message
-
-        self._translate_response(response, has_body=False, **kwargs)
-        return self
-
-    def get(self, session, remote_method,
-            error_message=None, requires_id=True):
-        """Get a remote resource based on this instance.
-
-        This function overrides default Resource.get to enable GET headers
-
-        :param session: The session to use for making this request.
-        :type session: :class:`~keystoneauth1.adapter.Adapter`
-        :param boolean requires_id: A boolean indicating whether resource ID
-                                    should be part of the requested URI.
-        :return: This :class:`Resource` instance.
-        :raises: :exc:`~openstack.exceptions.MethodNotSupported` if
-                 :data:`Resource.allow_get` is not set to ``True``.
-        """
-        if not self.allow_get:
-            raise exceptions.MethodNotSupported(self, "get")
-
-        request = self._prepare_request(requires_id=requires_id)
-        session = self._get_boto_session(session)
-        # sess = self._get_session(session)
-        # req_auth = self._get_req_auth(session)
-
-        response = None
-        try:
-            func = getattr(session, remote_method)
-            response = func(**request.body)
-        except ClientError as e:
-            raise exceptions.SDKException(_('Exception %s') % str(e))
-
-        kwargs = {}
-        if error_message:
-            kwargs['error_message'] = error_message
-
-        self._translate_response(response, **kwargs)
-
-        return self
-
-    @classmethod
-    def _list(cls, session, remote_func, normalize_func,
-              paginated=False, **params):
-        """Override default list to incorporate endpoint overriding
-        and custom headers
-
-        Since SDK Resource.list method is passing hardcoded headers
-        do override the function
-
-        This resource object list generator handles pagination and takes query
-        params for response filtering.
-
-        :param session: The session to use for making this request.
-        :type session: :class:`~keystoneauth1.adapter.Adapter`
-        :param remote_func: session function to be invoked
-        :param normalize_func: class function to translate response keys
-        :param bool paginated: ``True`` if a GET to this resource returns
-                               a paginated series of responses, or ``False``
-                               if a GET returns only one page of data.
-                               **When paginated is False only one
-                               page of data will be returned regardless
-                               of the API's support of pagination.**
-        :param dict params: These keyword arguments are passed through the
-            :meth:`~openstack.resource.QueryParamter._transpose` method
-            to find if any of them match expected query parameters to be
-            sent in the *params* argument to
-            :meth:`~keystoneauth1.adapter.Adapter.get`. They are additionally
-            checked against the
-            :data:`~openstack.resource.Resource.base_path` format string
-            to see if any path fragments need to be filled in by the contents
-            of this argument.
-
-        :return: A generator of :class:`Resource` objects.
-        :raises: :exc:`~openstack.exceptions.MethodNotSupported` if
-                 :data:`Resource.allow_list` is not set to ``True``.
-        :raises: :exc:`~openstack.exceptions.InvalidResourceQuery` if query
-                 contains invalid params.
-
-        """
-
-        if not cls.allow_list:
-            raise exceptions.MethodNotSupported(cls, "list")
-
-        session = cls._get_boto_session(session)
-
-        cls._query_mapping._validate(params, base_path=cls.base_path)
-        query_params = cls._query_mapping._transpose(params)
-        uri = cls.base_path % params
-
-        # limit = query_params.get('limit')
-
-        total_yielded = 0
-        while uri:
-            func = getattr(session, remote_func)
-            response = func(**query_params.copy())
-            # exceptions.raise_from_response(response_mock)
-            # data = response
-
-            if cls.resources_key:
-                resources = response[cls.resources_key]
+        if cls.OBS_NS in t.tag:
+            t.tag = t.tag.lstrip('{%s}' % (cls.OBS_NS))
+        d = {t.tag: {} if t.attrib else None}
+        children = list(t)
+        if children:
+            dd = defaultdict(list)
+            for dc in map(cls.etree_to_dict, children):
+                for k, v in dc.items():
+                    dd[k].append(v)
+            d = {t.tag: {k: v[0] if len(v) == 1 else v for k, v in dd.items()}}
+        if t.attrib:
+            d[t.tag].update(('@' + k, v) for k, v in t.attrib.items())
+        if t.text:
+            # strip spaces and quotes
+            text = t.text.strip(' "')
+            if children or t.attrib:
+                if text:
+                    d[t.tag]['#text'] = text
             else:
-                resources = response
-
-            if not isinstance(resources, list):
-                resources = [resources]
-
-            for raw_resource in resources:
-                # Do not allow keys called "self" through. Glance chose
-                # to name a key "self", so we need to pop it out because
-                # we can't send it through cls.existing and into the
-                # Resource initializer. "self" is already the first
-                # argument and is practically a reserved word.
-                raw_resource.pop("self", None)
-                func = getattr(cls, normalize_func)
-                resource = func(raw_resource)
-
-                value = cls.existing(**resource)
-
-                # marker = value.id
-                yield value
-                total_yielded += 1
-            return
+                d[t.tag] = text
+        return d

--- a/otcextensions/sdk/sdk_proxy.py
+++ b/otcextensions/sdk/sdk_proxy.py
@@ -19,7 +19,7 @@ _logger = _log.setup_logging('openstack')
 class Proxy(os_proxy.Proxy):
 
     def _find(self, resource_type, name_or_id, ignore_missing=True,
-              endpoint_override=None, headers=None,
+              endpoint_override=None, headers=None, requests_auth=None,
               **attrs):
         """Find a resource
 
@@ -39,6 +39,7 @@ class Proxy(os_proxy.Proxy):
                                     ignore_missing=ignore_missing,
                                     endpoint_override=endpoint_override,
                                     headers=headers,
+                                    requests_auth=requests_auth,
                                     **attrs)
         # Inject endpoint_override into the resource for potential
         # direct use (i.e. instance.reboot)
@@ -49,7 +50,7 @@ class Proxy(os_proxy.Proxy):
 
     @os_proxy._check_resource(strict=False)
     def _delete(self, resource_type, value, ignore_missing=True,
-                endpoint_override=None, headers=None,
+                endpoint_override=None, headers=None, requests_auth=None,
                 **attrs):
         """Delete a resource
 
@@ -89,7 +90,8 @@ class Proxy(os_proxy.Proxy):
                     )
                 ),
                 endpoint_override=endpoint_override,
-                headers=headers
+                headers=headers,
+                requests_auth=requests_auth
             )
         except exceptions.NotFoundException:
             if ignore_missing:
@@ -100,7 +102,7 @@ class Proxy(os_proxy.Proxy):
 
     @os_proxy._check_resource(strict=False)
     def _update(self, resource_type, value,
-                endpoint_override=None, headers=None,
+                endpoint_override=None, headers=None, requests_auth=None,
                 **attrs):
         """Update a resource
 
@@ -123,11 +125,12 @@ class Proxy(os_proxy.Proxy):
         return res.update(
             self,
             endpoint_override=endpoint_override,
-            headers=headers
+            headers=headers,
+            requests_auth=requests_auth
         )
 
     def _create(self, resource_type,
-                endpoint_override=None, headers=None,
+                endpoint_override=None, headers=None, requests_auth=None,
                 prepend_key=True,
                 **attrs):
         """Create a resource from attributes
@@ -151,6 +154,7 @@ class Proxy(os_proxy.Proxy):
             self,
             endpoint_override=endpoint_override,
             headers=headers,
+            requests_auth=requests_auth,
             prepend_key=prepend_key,
         )
 
@@ -163,7 +167,7 @@ class Proxy(os_proxy.Proxy):
 
     @os_proxy._check_resource(strict=False)
     def _get(self, resource_type, value=None, requires_id=True,
-             endpoint_override=None, headers=None,
+             endpoint_override=None, headers=None, requests_auth=None,
              **attrs):
         """Get a resource
 
@@ -189,7 +193,8 @@ class Proxy(os_proxy.Proxy):
             error_message="No {resource_type} found for {value}".format(
                 resource_type=resource_type.__name__, value=value),
             endpoint_override=endpoint_override,
-            headers=headers
+            headers=headers,
+            requests_auth=requests_auth,
         )
 
         # Inject endpoint_override into the resource for potential
@@ -200,7 +205,7 @@ class Proxy(os_proxy.Proxy):
         return persist
 
     def _list(self, resource_type, value=None, paginated=False,
-              endpoint_override=None, headers=None,
+              endpoint_override=None, headers=None, requests_auth=None,
               **attrs):
         """List a resource
 
@@ -228,10 +233,11 @@ class Proxy(os_proxy.Proxy):
         return res.list(self, paginated=paginated,
                         endpoint_override=endpoint_override,
                         headers=headers,
+                        requests_auth=requests_auth,
                         **attrs)
 
     def _head(self, resource_type, value=None,
-              endpoint_override=None, headers=None,
+              endpoint_override=None, headers=None, requests_auth=None,
               **attrs):
         """Retrieve a resource's header
 
@@ -252,5 +258,6 @@ class Proxy(os_proxy.Proxy):
         res = self._get_resource(resource_type, value, **attrs)
         return res.head(self,
                         endpoint_override=endpoint_override,
-                        headers=headers
+                        headers=headers,
+                        requests_auth=requests_auth,
                         )

--- a/otcextensions/sdk/sdk_resource.py
+++ b/otcextensions/sdk/sdk_resource.py
@@ -27,7 +27,8 @@ class Resource(resource.Resource):
     def _prepare_override_args(cls,
                                endpoint_override=None,
                                request_headers=None,
-                               additional_headers=None):
+                               additional_headers=None,
+                               requests_auth=None):
         """Prepare additional (override) arguments for the REST call
 
         :param endpoint_override: optional endpoint_override argument
@@ -55,6 +56,9 @@ class Resource(resource.Resource):
 
         if endpoint_override:
             req_args['endpoint_override'] = endpoint_override
+
+        if requests_auth:
+            req_args['requests_auth'] = requests_auth
 
         return req_args
 
@@ -87,8 +91,8 @@ class Resource(resource.Resource):
         self._header.attributes.update(headers)
         self._header.clean()
 
-    def create(self, session, prepend_key=True, requires_id=True,
-               endpoint_override=None, headers=None):
+    def create(self, session, prepend_key=True,
+               endpoint_override=None, headers=None, requests_auth=None):
         """Create a remote resource based on this instance.
 
         :param session: The session to use for making this request.
@@ -112,7 +116,8 @@ class Resource(resource.Resource):
             req_args = self._prepare_override_args(
                 endpoint_override=endpoint_override,
                 request_headers=request.headers,
-                additional_headers=headers)
+                additional_headers=headers,
+                requests_auth=requests_auth)
             response = session.put(request.url,
                                    json=request.body, **req_args)
         elif self.create_method == 'POST':
@@ -121,7 +126,8 @@ class Resource(resource.Resource):
             req_args = self._prepare_override_args(
                 endpoint_override=endpoint_override,
                 request_headers=request.headers,
-                additional_headers=headers)
+                additional_headers=headers,
+                requests_auth=requests_auth)
             response = session.post(request.url,
                                     json=request.body, **req_args)
         else:
@@ -133,7 +139,7 @@ class Resource(resource.Resource):
         return self
 
     def get(self, session, error_message=None, requires_id=True,
-            endpoint_override=None, headers=None):
+            endpoint_override=None, headers=None, requests_auth=None):
         """Get a remote resource based on this instance.
 
         This function overrides default Resource.get to enable GET headers
@@ -156,7 +162,8 @@ class Resource(resource.Resource):
         get_args = self._prepare_override_args(
             endpoint_override=endpoint_override,
             request_headers=request.headers,
-            additional_headers=headers)
+            additional_headers=headers,
+            requests_auth=requests_auth)
 
         response = session.get(request.url, **get_args)
         kwargs = {}
@@ -168,7 +175,7 @@ class Resource(resource.Resource):
         return self
 
     def head(self, session,
-             endpoint_override=None, headers=None):
+             endpoint_override=None, headers=None, requests_auth=None):
         """Get headers from a remote resource based on this instance.
 
         :param session: The session to use for making this request.
@@ -197,7 +204,7 @@ class Resource(resource.Resource):
         return self
 
     def update(self, session, prepend_key=True, has_body=True,
-               endpoint_override=None, headers=None):
+               endpoint_override=None, headers=None, requests_auth=None):
         """Update the remote resource based on this instance.
 
         :param session: The session to use for making this request.
@@ -226,7 +233,8 @@ class Resource(resource.Resource):
         args = self._prepare_override_args(
             endpoint_override=endpoint_override,
             request_headers=request.headers,
-            additional_headers=headers)
+            additional_headers=headers,
+            requests_auth=requests_auth)
 
         if self.update_method == 'PATCH':
             response = session.patch(
@@ -245,7 +253,8 @@ class Resource(resource.Resource):
         return self
 
     def delete(self, session, error_message=None,
-               endpoint_override=None, headers=None, params=None):
+               endpoint_override=None, headers=None,
+               requests_auth=None, params=None):
         """Delete the remote resource based on this instance.
 
         This function overrides default Resource.delete to enable headers
@@ -267,7 +276,8 @@ class Resource(resource.Resource):
         delete_args = self._prepare_override_args(
             endpoint_override=endpoint_override,
             request_headers=request.headers,
-            additional_headers=headers)
+            additional_headers=headers,
+            requests_auth=requests_auth)
         if params:
             delete_args['params'] = params
 
@@ -282,7 +292,8 @@ class Resource(resource.Resource):
 
     @classmethod
     def list(cls, session, paginated=False,
-             endpoint_override=None, headers=None, **params):
+             endpoint_override=None, headers=None, requests_auth=None,
+             **params):
         """Override default list to incorporate endpoint overriding
         and custom headers
 

--- a/otcextensions/tests/functional/osclient/obs/v1/test_container.py
+++ b/otcextensions/tests/functional/osclient/obs/v1/test_container.py
@@ -1,0 +1,64 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+import uuid
+
+import fixtures
+
+from openstackclient.tests.functional import base
+
+
+CREATE_COMMAND = 'obs container create %(name)s -f json'
+
+DELETE_COMMAND = 'obs container delete %(name)s'
+
+
+class ObsContainerTests(base.TestCase):
+    """Functional tests for vbs. """
+
+    NAME = uuid.uuid4().hex
+    OTHER_NAME = uuid.uuid4().hex
+
+    @classmethod
+    def setUpClass(cls):
+        super(ObsContainerTests, cls).setUpClass()
+        json_output = json.loads(cls.openstack(
+            CREATE_COMMAND % {'name': cls.NAME}
+        ))
+        cls.container_id = json_output["id"]
+        cls.assertOutput(cls.NAME, json_output['name'])
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.openstack(
+                DELETE_COMMAND % {'name': cls.NAME}
+            )
+        finally:
+            super(ObsContainerTests, cls).tearDownClass()
+
+    def setUp(self):
+        super(ObsContainerTests, self).setUp()
+        ver_fixture = fixtures.EnvironmentVariable(
+            'OS_OBS_API_VERSION', '1'
+        )
+        self.useFixture(ver_fixture)
+
+    def test_container_list(self):
+        json_output = json.loads(self.openstack(
+            'obs container list -f json '
+        ))
+        self.assertIn(
+            self.NAME,
+            [cont['name'] for cont in json_output]
+        )

--- a/otcextensions/tests/functional/osclient/obs/v1/test_obj.py
+++ b/otcextensions/tests/functional/osclient/obs/v1/test_obj.py
@@ -1,0 +1,101 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+import filecmp
+import os
+import uuid
+
+import fixtures
+
+from openstackclient.tests.functional import base
+
+
+CONTAINER_CREATE_COMMAND = 'obs container create %(name)s -f json'
+OBJECT_CREATE_COMMAND = 'obs object create %(container)s %(name)s -f json'
+
+CONTAINER_DELETE_COMMAND = 'obs container delete %(name)s'
+OBJECT_DELETE_COMMAND = 'obs object delete %(container)s %(name)s'
+
+
+class ObsObjectTests(base.TestCase):
+    """Functional tests for vbs. """
+
+    CONTAINER_NAME = uuid.uuid4().hex
+    OBJECT_NAME = uuid.uuid4().hex + '.tmp'
+
+    OBJECT_CONTENT = uuid.uuid4().hex
+
+    @classmethod
+    def setUpClass(cls):
+        super(ObsObjectTests, cls).setUpClass()
+        json_output = json.loads(cls.openstack(
+            CONTAINER_CREATE_COMMAND % {'name': cls.CONTAINER_NAME}
+        ))
+        cls.container_id = json_output["id"]
+        cls.assertOutput(cls.CONTAINER_NAME, json_output['name'])
+        with open(cls.OBJECT_NAME, 'w') as file:
+            file.write(cls.OBJECT_CONTENT)
+        json_output = json.loads(cls.openstack(
+            OBJECT_CREATE_COMMAND % {
+                'name': cls.OBJECT_NAME,
+                'container': cls.CONTAINER_NAME
+            }
+        ))
+        cls.object_id = json_output["id"]
+        cls.assertOutput(cls.OBJECT_NAME, json_output['name'])
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.openstack(
+                OBJECT_DELETE_COMMAND % {
+                    'name': cls.OBJECT_NAME,
+                    'container': cls.CONTAINER_NAME
+                }
+            )
+            cls.openstack(
+                CONTAINER_DELETE_COMMAND % {'name': cls.CONTAINER_NAME}
+            )
+            os.remove(cls.OBJECT_NAME)
+        finally:
+            super(ObsObjectTests, cls).tearDownClass()
+
+    def setUp(self):
+        super(ObsObjectTests, self).setUp()
+        ver_fixture = fixtures.EnvironmentVariable(
+            'OS_OBS_API_VERSION', '1'
+        )
+        self.useFixture(ver_fixture)
+
+    def test_object_list(self):
+        json_output = json.loads(self.openstack(
+            'obs object list %(container)s -f json ' % {
+                'container': self.CONTAINER_NAME
+            }
+        ))
+        self.assertIn(
+            self.OBJECT_NAME,
+            [cont['name'] for cont in json_output]
+        )
+
+    def test_object_save(self):
+        download_name = self.OBJECT_NAME + '_output'
+        self.openstack(
+            'obs object save %(container)s %(name)s --file %(output)s' % {
+                'container': self.CONTAINER_NAME,
+                'name': self.OBJECT_NAME,
+                'output': download_name
+            }
+        )
+        self.assertTrue(filecmp.cmp(self.OBJECT_NAME, download_name))
+        os.remove(download_name)

--- a/otcextensions/tests/unit/sdk/cce/v1/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/cce/v1/test_proxy.py
@@ -117,7 +117,8 @@ class TestCCEClusterNode(TestCCEProxy):
                 expected_kwargs={
                     'endpoint_override': None,
                     'headers': None,
-                    'prepend_key': True
+                    'prepend_key': True,
+                    'requests_auth': None
                 }
             )
 

--- a/otcextensions/tests/unit/sdk/dms/v1/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/dms/v1/test_proxy.py
@@ -109,7 +109,8 @@ class TestDMSProxy(test_proxy_base.TestProxyBase):
                 'consumer_group_id': 'group',
                 'endpoint_override': None,
                 'headers': None,
-                'paginated': False})
+                'paginated': False,
+                'requests_auth': None})
 
     def test_ack_consumed_message(self):
         pass

--- a/otcextensions/tests/unit/sdk/obs/v1/test_container.py
+++ b/otcextensions/tests/unit/sdk/obs/v1/test_container.py
@@ -1,0 +1,103 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import mock
+
+from keystoneauth1 import adapter
+
+from openstack.tests.unit import base
+
+from otcextensions.sdk.obs.v1 import container
+
+
+EXAMPLE = {
+    "Name": "container_name",
+    "CreationDate": "2013-01-15T05:52:15.920Z<",
+}
+
+EXAMPLE_LIST = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ListAllMyBucketsResult xmlns="http://obs.otc.t-systems.com/doc/2016-01-01/">
+<Owner><ID>some_id</ID>
+<DisplayName></DisplayName>
+</Owner><Buckets>
+<Bucket><Name>test-v1</Name>
+<CreationDate>2018-10-02T08:54:55.885Z</CreationDate></Bucket>
+<Bucket><Name>test-v2</Name>
+<CreationDate>2018-09-19T12:47:22.205Z</CreationDate></Bucket>
+</Buckets></ListAllMyBucketsResult>
+"""
+
+
+class TestContainer(base.TestCase):
+
+    def setUp(self):
+        super(TestContainer, self).setUp()
+        self.sess = mock.Mock(spec=adapter.Adapter)
+        self.sess.get = mock.Mock()
+        self.sess.put = mock.Mock()
+
+    def test_basic(self):
+        sot = container.Container()
+
+        self.assertEqual('/', sot.base_path)
+
+        self.assertTrue(sot.allow_list)
+        self.assertTrue(sot.allow_get)
+        self.assertTrue(sot.allow_head)
+        self.assertTrue(sot.allow_create)
+        self.assertTrue(sot.allow_delete)
+
+    def test_make_it(self):
+
+        sot = container.Container(**EXAMPLE)
+        self.assertEqual(EXAMPLE['Name'], sot.id)
+        self.assertEqual(EXAMPLE['Name'], sot.name)
+        self.assertEqual(EXAMPLE['CreationDate'], sot.creation_date)
+
+    def test_list(self):
+
+        sot = container.Container()
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.content = EXAMPLE_LIST
+
+        self.sess.get.return_value = mock_response
+
+        result = list(sot.list(
+            self.sess,
+        ))
+
+        self.assertEqual(2, len(result))
+        self.assertEqual('test-v1', result[0].name)
+        self.assertEqual('test-v2', result[1].name)
+
+    def test_create(self):
+
+        sot = container.Container(name='test-v1')
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.content = ''
+
+        self.sess.put.return_value = mock_response
+
+        sot.create(
+            self.sess,
+            endpoint_override='epo',
+            requests_auth=2)
+
+        self.sess.put.assert_called_once_with(
+            '/',
+            data=None,
+            endpoint_override='epo',
+            requests_auth=2
+        )

--- a/otcextensions/tests/unit/sdk/obs/v1/test_obj.py
+++ b/otcextensions/tests/unit/sdk/obs/v1/test_obj.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import base64
+import mock
+import hashlib
+
+from keystoneauth1 import adapter
+
+from openstack.tests.unit import base
+
+from otcextensions.sdk.obs.v1 import obj
+
+
+EXAMPLE = {
+    "Key": "name",
+    "LastModified": "2013-01-15T05:52:15.920Z<",
+    "ETag": "etag",
+}
+
+EXAMPLE_LIST = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ListBucketResult xmlns="http://obs.otc.t-systems.com/doc/2016-01-01/">
+<Name>ag-test-v1</Name><Prefix></Prefix><Marker></Marker>
+<MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>
+<Contents><Key>setup.py</Key>
+<LastModified>2018-10-02T10:17:04.666Z</LastModified>
+<ETag>"9c24605289b49ad77a51ba7986425158"</ETag>
+<Size>1030</Size><Owner><ID>859d69896ff44ba6a20845edb43f311e</ID>
+<DisplayName>OTC00000000001000000448</DisplayName></Owner>
+<StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+"""
+
+
+class TestObject(base.TestCase):
+
+    def setUp(self):
+        super(TestObject, self).setUp()
+        self.sess = mock.Mock(spec=adapter.Adapter)
+        self.sess.get = mock.Mock()
+        self.sess.put = mock.Mock()
+
+    def test_basic(self):
+        sot = obj.Object()
+
+        self.assertEqual('/', sot.base_path)
+
+        self.assertTrue(sot.allow_list)
+        self.assertTrue(sot.allow_get)
+        self.assertTrue(sot.allow_head)
+        self.assertTrue(sot.allow_create)
+        self.assertTrue(sot.allow_delete)
+
+    def test_make_it(self):
+
+        sot = obj.Object(**EXAMPLE)
+        self.assertEqual(EXAMPLE['Key'], sot.id)
+        self.assertEqual(EXAMPLE['Key'], sot.name)
+        self.assertEqual(EXAMPLE['LastModified'], sot.last_modified)
+        self.assertEqual(EXAMPLE['ETag'], sot.etag)
+
+    def test_list(self):
+
+        sot = obj.Object()
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.content = EXAMPLE_LIST
+
+        self.sess.get.return_value = mock_response
+
+        result = list(sot.list(
+            self.sess,
+        ))
+
+        self.assertEqual(1, len(result))
+        self.assertEqual('setup.py', result[0].name)
+        self.assertEqual('9c24605289b49ad77a51ba7986425158', result[0].etag)
+        self.assertEqual(1030, result[0].content_length)
+
+    def test_create(self):
+
+        data = 'some test data'
+        md5 = hashlib.md5()
+        md5.update(str.encode(data))
+        data_md5 = base64.b64encode(md5.digest()).decode()
+        sot = obj.Object(name='test-v1', data=data)
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.content = ''
+
+        self.sess.put.return_value = mock_response
+
+        sot.create(
+            self.sess,
+            endpoint_override='epo',
+            requests_auth=2)
+
+        self.sess.put.assert_called_once_with(
+            '/test-v1',
+            data=data,
+            endpoint_override='epo',
+            requests_auth=2,
+            headers={
+                'Content-MD5': data_md5
+            }
+        )
+    #

--- a/otcextensions/tests/unit/sdk/obs/v1/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/obs/v1/test_proxy.py
@@ -14,12 +14,173 @@ from openstack.tests.unit import test_proxy_base
 
 from otcextensions.sdk.obs.v1 import _proxy
 
+from otcextensions.sdk.ak_auth import AKRequestsAuth
+
+from otcextensions.sdk.obs.v1 import container as _container
+from otcextensions.sdk.obs.v1 import obj as _obj
+
 
 class TestObsProxy(test_proxy_base.TestProxyBase):
-
-    PROJECT_ID = '123'
 
     def setUp(self):
         super(TestObsProxy, self).setUp()
         self.proxy = _proxy.Proxy(self.session)
-        self.session.get_project_id.side_effect = [TestObsProxy.PROJECT_ID]
+
+        self._ak_auth = AKRequestsAuth(
+            access_key='ak',
+            secret_access_key='sk',
+            host='host',
+            region='regio',
+            service='OBS')
+        self.proxy._ak_auth = self._ak_auth
+        self.proxy.region_name = 'regio'
+
+    def test_containers(self):
+        self.verify_list(
+            self.proxy.containers, _container.Container, paginated=True,
+            mock_method='otcextensions.sdk.sdk_proxy.Proxy._list',
+            expected_kwargs={
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_create_container(self):
+        self.verify_create(
+            self.proxy.create_container, _container.Container,
+            mock_method='otcextensions.sdk.sdk_proxy.Proxy._create',
+            method_kwargs={
+                'name': 'nm'
+            },
+            expected_kwargs={
+                'name': 'nm',
+                'endpoint_override': 'https://nm.obs.regio.otc.t-systems.com',
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_delete_container(self):
+        self.verify_delete(
+            self.proxy.delete_container, _container.Container, ignore=True,
+            mock_method='otcextensions.sdk.sdk_proxy.Proxy._delete',
+            expected_kwargs={
+                'endpoint_override': 'https://resource_or_id.obs.regio.'
+                                     'otc.t-systems.com',
+                'ignore_missing': True,
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_get_container_metadata(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.get_container_metadata,
+            'container'
+        )
+
+    def test_set_container_metadata(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.set_container_metadata,
+            'container',
+            metadata={}
+        )
+
+    def test_delete_container_metadata(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.delete_container_metadata,
+            'container',
+            keys={}
+        )
+
+    def test_objects(self):
+        self.verify_list(
+            self.proxy.objects, _obj.Object, paginated=True,
+            mock_method='otcextensions.sdk.sdk_proxy.Proxy._list',
+            method_args={
+                'container': 'container'
+            },
+            expected_kwargs={
+                'endpoint_override': 'https://container.obs.regio.'
+                                     'otc.t-systems.com',
+                'paginated': True,
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_create_object(self):
+        self.verify_create(
+            self.proxy.create_object, _obj.Object,
+            mock_method='otcextensions.sdk.sdk_proxy.Proxy._create',
+            method_kwargs={
+                'name': 'nm',
+                'container': 'container'
+            },
+            expected_kwargs={
+                'name': 'nm',
+                'endpoint_override': 'https://container.obs.regio.otc.'
+                                     't-systems.com',
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_delete_object(self):
+        self.verify_delete(
+            self.proxy.delete_object, _obj.Object, ignore=True,
+            mock_method='otcextensions.sdk.sdk_proxy.Proxy._delete',
+            expected_kwargs={
+                'endpoint_override': 'https://None.obs.regio.'
+                                     'otc.t-systems.com',
+                'ignore_missing': True,
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_download_object(self):
+        self._verify2(
+            'otcextensions.sdk.obs.v1.obj.Object.download',
+            self.proxy.download_object,
+            method_args=[{}],
+            method_kwargs={'container': 'cont'},
+            expected_args=[self.proxy],
+            expected_kwargs={
+                'filename': '-',
+                'endpoint_override': 'https://cont.obs.regio.'
+                                     'otc.t-systems.com',
+                'requests_auth': self._ak_auth
+            }
+        )
+
+    def test_stream_object(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.stream_object,
+            'container',
+        )
+
+    def test_copy_object(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.copy_object,
+        )
+
+    def test_get_object_metadata(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.get_object_metadata,
+            'container',
+        )
+
+    def test_set_object_metadata(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.set_object_metadata,
+            'container',
+        )
+
+    def test_delete_object_metadata(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.proxy.delete_object_metadata,
+            'container',
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@
 # process, which may cause wedges in the gate later.
 
 openstacksdk>=0.16.0 # Apache-2.0
-boto3>=1.4.6 # ASL-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,5 +16,3 @@ testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 python-openstackclient>=3.12.1 # Apache-2.0
 tempest>=17.1.0 # Apache-2.0
-
-boto3>=1.4.6 # ASL-2.0


### PR DESCRIPTION
remove boto3 module in favor of internally implemented requests_auth 
plugin to reduce external dependencies and problems with different 
versions in different distros

Address issue #18 