### PR TITLE
Small changes to CCE module

### DIFF
--- a/otcextensions/osclient/cce/client.py
+++ b/otcextensions/osclient/cce/client.py
@@ -21,7 +21,7 @@ from otcextensions.i18n import _
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_API_VERSION = '1.0'
+DEFAULT_API_VERSION = '3'
 API_VERSION_OPTION = 'os_cce_api_version'
 API_NAME = "cce"
 API_VERSIONS = {

--- a/otcextensions/osclient/cce/v2/cluster.py
+++ b/otcextensions/osclient/cce/v2/cluster.py
@@ -140,6 +140,7 @@ class CreateCCECluster(command.Command):
         parser.add_argument(
             '--flavor',
             metavar='<flavor>',
+	    required=True,
             help=_('Cluster flavor.')
         )
         parser.add_argument(

--- a/otcextensions/osclient/cce/v2/cluster_node.py
+++ b/otcextensions/osclient/cce/v2/cluster_node.py
@@ -193,6 +193,7 @@ class CreateCCEClusterNode(command.Command):
         parser.add_argument(
             '--availability_zone',
             metavar='<availability_zone>',
+	    required=True,
             help=_('Availability zone to place server in.')
         )
         parser.add_argument(
@@ -231,7 +232,7 @@ class CreateCCEClusterNode(command.Command):
                 raise argparse.ArgumentTypeError(msg)
             # Size only relevant for data disk
             if disk_parts[1].isdigit:
-                disk_data['size'] = disk_parts[1]
+                disk_data['size'] = int(disk_parts[1])
             else:
                 msg = _('Volume SIZE is not a digit')
                 raise argparse.ArgumentTypeError(msg)
@@ -243,8 +244,6 @@ class CreateCCEClusterNode(command.Command):
     def take_action(self, parsed_args):
 
         attrs = {'metadata': {}}
-
-        attrs['metadata']['name'] = parsed_args.cluster
 
         spec = {}
         spec['flavor'] = parsed_args.flavor

--- a/otcextensions/sdk/cce/cce_service.py
+++ b/otcextensions/sdk/cce/cce_service.py
@@ -42,7 +42,7 @@ class CceService(service_description.ServiceDescription):
 
         # First, check to see if we've got config that matches what we
         # understand in the SDK.
-        version_string = config.get_api_version('cce') or '1'
+        version_string = config.get_api_version('cce') or '3'
         endpoint_override = config.get_endpoint(self.service_type)
 
         epo = self.endpoint_override.get(version_string, None)


### PR DESCRIPTION
-          Changed the default version to CCEv2 – CCEv1 will be deprecated soon
-          Changed the volume size to int, otherwise the API gateway returns bad request
-          Change a few parameters to required, all according the API documents
-          Deleted the node name for cluster node creation as it is not mandatory. CCE will use automatically the cluster name with a random string