### PR TITLE
fix: adjust spelling and include password attribute to resource

### DIFF
--- a/otcextensions/osclient/dcs/v1/instance.py
+++ b/otcextensions/osclient/dcs/v1/instance.py
@@ -185,7 +185,7 @@ class CreateInstance(command.ShowOne):
         parser.add_argument(
             '--engine',
             metavar='<engine>',
-            default='redis',
+            default='Redis',
             help=_('Cache engine, which is Redis.')
         )
         parser.add_argument(

--- a/otcextensions/sdk/dcs/v1/instance.py
+++ b/otcextensions/sdk/dcs/v1/instance.py
@@ -85,6 +85,8 @@ class Instance(resource.Resource):
     #: billing mode. In other billing modes, no value is returned
     #: for this parameter.
     order_id = resource.Body('order_id')
+    #: Password.
+    password = resource.Body('password')
     #: Port of the cache node.
     port = resource.Body('port')
     #: Product ID used to differentiate DCS instance types.


### PR DESCRIPTION
1/ The default for the "--engine" argument was previously "redis", while the API expected "Redis" with a capital letter.
2/ Even if passing a complying password with "--password", the SDK would not pass the value to the API.