### PR TITLE
Fix CCE endpoint overriding

### DIFF
--- a/otcextensions/sdk/cce/cce_service.py
+++ b/otcextensions/sdk/cce/cce_service.py
@@ -26,12 +26,6 @@ class CceService(service_description.ServiceDescription):
         '3': _proxy_v3.Proxy
     }
 
-    endpoint_override = {
-        '1': 'https://cce.eu-de.otc.t-systems.com/api/v1',
-        '3': 'https://cce.eu-de.otc.t-systems.com/api/v3/'
-             'projects/%(project_id)s',
-    }
-
     def _make_proxy(self, instance):
         """Create a Proxy for the service in question.
 
@@ -44,8 +38,16 @@ class CceService(service_description.ServiceDescription):
         # understand in the SDK.
         version_string = config.get_api_version('cce') or '3'
         endpoint_override = config.get_endpoint(self.service_type)
+        ep = config.get_service_catalog().url_for(
+            service_type=self.service_type,
+            region_name=config.region_name)
 
-        epo = self.endpoint_override.get(version_string, None)
+        epo = '%(base)s/api/v%(ver)s' % {
+            'base': ep,
+            'ver': version_string}
+        if version_string == '3':
+            epo += '/projects/%(project_id)s'
+
         if epo and not endpoint_override:
             endpoint_override = epo
 

--- a/otcextensions/tests/unit/sdk/base.py
+++ b/otcextensions/tests/unit/sdk/base.py
@@ -30,6 +30,10 @@ class TestCase(base.TestCase):
         ets_rds = self.os_fixture._get_endpoint_templates('rdsv3')
         svc_rds = self.os_fixture.v3_token.add_service('rdsv3', name='rdsv3')
         svc_rds.add_standard_endpoints(region='RegionOne', **ets_rds)
+        ets_cce = self.os_fixture._get_endpoint_templates('ccev2.0')
+        svc_cce = self.os_fixture.v3_token.add_service('ccev2.0',
+                                                       name='ccev2.0')
+        svc_cce.add_standard_endpoints(region='RegionOne', **ets_cce)
 
         return super(TestCase, self).get_keystone_v3_token()
 
@@ -49,7 +53,7 @@ class TestCase(base.TestCase):
                     append=None, base_url_append=None,
                     qs_elements=None):
         endpoint_url = (
-            'https://cce.eu-de.otc.t-systems.com/'
+            'https://ccev2.0.example.com/'
             'api/v3/projects/%(project_id)s'
         ) % {'project_id': self.cloud.current_project_id}
         # Strip trailing slashes, so as not to produce double-slashes below

--- a/otcextensions/tests/unit/sdk/cce/v3/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/cce/v3/test_proxy.py
@@ -171,3 +171,39 @@ class TestCCEJob(TestCCEProxy):
             expected_kwargs={'attribute': 'status.status'}
         )
         self.proxy.get_job.assert_called_with('fake_job_id')
+
+
+class TestExtractName(TestCCEProxy):
+
+    def test_extract_name(self):
+
+        self.assertEqual(
+            ['discovery'],
+            self.proxy._extract_name('/api/v3/projects/123', project_id='123')
+        )
+        self.assertEqual(
+            ['clusters'],
+            self.proxy._extract_name(
+                '/api/v3/projects/123/clusters', project_id='123')
+        )
+        self.assertEqual(
+            ['cluster'],
+            self.proxy._extract_name(
+                '/api/v3/projects/123/clusters/c1', project_id='123')
+        )
+        self.assertEqual(
+            ['cluster', 'clustercert'],
+            self.proxy._extract_name(
+                '/api/v3/projects/123/clusters/c1/clustercert',
+                project_id='123')
+        )
+        self.assertEqual(
+            ['cluster', 'nodes'],
+            self.proxy._extract_name(
+                '/api/v3/projects/123/clusters/c1/nodes', project_id='123')
+        )
+        self.assertEqual(
+            ['cluster', 'node'],
+            self.proxy._extract_name(
+                '/api/v3/projects/123/clusters/c1/nodes/n1', project_id='123')
+        )


### PR DESCRIPTION
Fir the way how we workaround broken service catalog configuration, so
that we can use OTCE for other environments also (ensure
/api/v3/projects/__project_id__ instead of hardcoding).
Also fix metric naming for CCE not to cause explosure on the influx
side.