### PR TITLE
Fix error message for showing missing cluster

### DIFF
--- a/otcextensions/osclient/cce/v2/cluster.py
+++ b/otcextensions/osclient/cce/v2/cluster.py
@@ -82,7 +82,7 @@ class ShowCCECluster(command.ShowOne):
     def take_action(self, parsed_args):
         client = self.app.client_manager.cce
 
-        obj = client.find_cluster(parsed_args.cluster)
+        obj = client.find_cluster(parsed_args.cluster, ignore_missing=False)
 
         # display_columns, columns = _get_columns(obj)
         data = utils.get_dict_properties(_flatten_cluster(obj), self.columns)

--- a/otcextensions/tests/unit/osclient/cce/v2/test_cluster.py
+++ b/otcextensions/tests/unit/osclient/cce/v2/test_cluster.py
@@ -141,7 +141,10 @@ class TestClusterShow(fakes.TestCCE):
         # Trigger the action
         columns, data = self.cmd.take_action(parsed_args)
 
-        self.client.find_cluster.assert_called_once_with('cluster_uuid', ignore_missing=False)
+        self.client.find_cluster.assert_called_once_with(
+            'cluster_uuid',
+            ignore_missing=False
+        )
 
         self.assertEqual(self.columns, columns)
         self.assertEqual(self.data, data)

--- a/otcextensions/tests/unit/osclient/cce/v2/test_cluster.py
+++ b/otcextensions/tests/unit/osclient/cce/v2/test_cluster.py
@@ -141,7 +141,7 @@ class TestClusterShow(fakes.TestCCE):
         # Trigger the action
         columns, data = self.cmd.take_action(parsed_args)
 
-        self.client.find_cluster.assert_called_once_with('cluster_uuid')
+        self.client.find_cluster.assert_called_once_with('cluster_uuid', ignore_missing=False)
 
         self.assertEqual(self.columns, columns)
         self.assertEqual(self.data, data)


### PR DESCRIPTION
Use `ignore_missing=False` in `ShowCCECluster.take_action`

Fix #152 

*Acceptance test:*
```
$ /home/akachuri/PycharmProjects/python-otcextensions/.tox/venv/bin/python -m openstackclient.shell --os-cloud machine cce cluster show asv
No Cluster found for asv
```