### PR TITLE
Initialize releasenotes building

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -29,6 +29,7 @@
     templates:
       - publish-to-pypi
       - publish-otc-docs-pti
+      - release-notes-jobs
     check:
       jobs:
         - otc-tox-pep8

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,9 +3,9 @@
 # process, which may cause wedges in the gate later.
 docutils>=0.11 # OSI-Approved Open Source, Public Domain
 beautifulsoup4>=4.6.0 # MIT
-reno>=2.5.0 # Apache-2.0
+reno>=3.1.0 # Apache-2.0
 otcdocstheme # Apache-2.0
-sphinx>=1.8.0,!=2.1.0 # BSD
+sphinx>=2.0.0,!=2.1.0 # BSD
 sphinxcontrib-apidoc>=0.2.0 # BSD
 cliff!=2.9.0,>=2.8.0 # Apache-2.0
 oslo.i18n>=3.15.3 # Apache-2.0

--- a/releasenotes/notes/init-releasenotes-4a5cb66ad7d34c38.yaml
+++ b/releasenotes/notes/init-releasenotes-4a5cb66ad7d34c38.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Initializes releasenotes building.

--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 import os
-import sys
 import warnings
 
 # -- General configuration ----------------------------------------------------
@@ -20,13 +19,12 @@ import warnings
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    'reno.sphinxext',
     'otcdocstheme',
-    'cliff.sphinxext',
 ]
 
 # openstackdocstheme options
-#otcdocs_repo_name = 'opentelekomcloud/python-otcextensions'
+otcdocs_repo = 'opentelekomcloud/python-otcextensions'
 html_last_updated_fmt = '%Y-%m-%d %H:%M'
 html_theme = 'otcdocs'
 
@@ -38,12 +36,6 @@ enforcer_warnings_as_errors = False
 # autodoc generation is a bit aggressive and a nuisance when doing heavy
 # text edit cycles.
 # execute "export SPHINX_DEBUG=1" in your terminal to disable
-
-# The suffix of source filenames.
-source_suffix = '.rst'
-
-# The master toctree document.
-master_doc = 'index'
 
 # General information about the project.
 project = u'python-otcextensions'
@@ -102,11 +94,3 @@ latex_documents = [
 
 # Include both the class and __init__ docstrings when describing the class
 autoclass_content = "both"
-
-# -- Options for cliff.sphinxext plugin ---------------------------------------
-
-autoprogram_cliff_application = 'openstack'
-
-autoprogram_cliff_ignored = [
-    '--help', '--format', '--column', '--max-width', '--fit-width',
-    '--print-empty', '--prefix', '--noindent', '--quote']

--- a/releasenotes/source/index.rst
+++ b/releasenotes/source/index.rst
@@ -1,0 +1,5 @@
+============================
+ otcextensions Release Notes
+============================
+
+.. release-notes::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = otcextensions
 summary = Open Telekom Cloud specific extensions for the OpenStack Client CLI and OpenStack SDK
-description-file =
+description_file =
     README.rst
 author = Artem Goncharov
-author-email = artem.goncharov@gmail.com
-home-page = http://python-otcextensions.readthedocs.io/
+author_email = artem.goncharov@gmail.com
+home_page = http://python-otcextensions.readthedocs.io/
 classifier =
     Environment :: OpenStack
     Intended Audience :: Information Technology
@@ -54,8 +54,8 @@ openstack.cbr.v3 =
   cbr_policy_list = otcextensions.osclient.cbr.v3.policy:ListPolicies
   cbr_policy_show = otcextensions.osclient.cbr.v3.policy:ShowPolicy
   cbr_policy_create = otcextensions.osclient.cbr.v3.policy:CreatePolicy
-  cbr_policy_update = otcextensions.osclient.cbr.v3.policy:UpdatePolicy  
-  cbr_policy_delete = otcextensions.osclient.cbr.v3.policy:DeletePolicy  
+  cbr_policy_update = otcextensions.osclient.cbr.v3.policy:UpdatePolicy
+  cbr_policy_delete = otcextensions.osclient.cbr.v3.policy:DeletePolicy
 
 #openstack.obs.v1 =
 #  s3_ls = otcextensions.osclient.obs.v1.ls:List
@@ -368,13 +368,13 @@ openstack.iam.v3 =
 
 [build_sphinx]
 builders = html,man
-all-files = 1
-warning-is-error = 0
-source-dir = doc/source
-build-dir = doc/build
+all_files = 1
+warning_is_error = 0
+source_dir = doc/source
+build_dir = doc/build
 
 [upload_sphinx]
-upload-dir = doc/build/html
+upload_dir = doc/build/html
 
 [wheel]
 universal = 1
@@ -392,3 +392,4 @@ input_file = otcextensions/locale/otcextensions.pot
 [compile_catalog]
 directory = otcextensions/locale
 domain = otcextensions
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 3.1
+minversion = 3.6
 envlist = py36,py37,pep8
 skipsdist = True
 ignore_basepython_conflict = True
@@ -17,7 +17,7 @@ setenv =
     OS_STDOUT_CAPTURE={env:OS_STDOUT_CAPTURE:true}
     OS_STDERR_CAPTURE={env:OS_STDERR_CAPTURE:true}
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/requirements.txt
 commands = stestr run {posargs}
@@ -41,7 +41,7 @@ commands =
 
 [testenv:venv]
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/doc/requirements.txt
@@ -66,18 +66,16 @@ commands =
 [testenv:docs]
 deps =
     -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
-#    -r{toxinidir}/requirements.txt
     -r{toxinidir}/doc/requirements.txt
 commands =
-    sphinx-build -W -d doc/build/doctrees --keep-going -b html doc/source/ doc/build/html
+    sphinx-build -W --keep-going -b html doc/source/ doc/build/html
 
 [testenv:releasenotes]
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
-    -r{toxinidir}/requirements.txt
+    -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
     -r{toxinidir}/doc/requirements.txt
 commands =
-    sphinx-build -a -E -W -d releasenotes/build/doctrees --keep-going -b html releasenotes/source releasenotes/build/html
+    sphinx-build -W --keep-going -b html releasenotes/source releasenotes/build/html
 
 [flake8]
 # The following are ignored on purpose. It's not super worth it to fix them.


### PR DESCRIPTION
- init releasenotes structure
- fix tox.ini
- enable releasenotes template
- fix deprecated "-" separation in setuptools
- adapt docs to be inline with latest theme release

Depends-On: https://github.com/opentelekomcloud-infra/otc-zuul-jobs/pull/70
