### PR TITLE
Fix tearDown in test fixtures

### DIFF
--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/base.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/base.py
@@ -1,0 +1,149 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+import uuid
+
+import fixtures
+
+from openstack import exceptions
+from openstack import _log
+from otcextensions.tests.functional import base
+
+_logger = _log.setup_logging('openstack')
+
+
+class BaseASTest(base.BaseFunctionalTest):
+
+    UUID = uuid.uuid4().hex[:9]
+    NETWORK_NAME = "test-network-" + UUID
+    SUBNET_NAME = "test-subnet-" + UUID
+    ROUTER_NAME = "test-router-" + UUID
+    SG_NAME = "test-sec-group-" + UUID
+    KP_NAME = "test-kp-" + UUID
+    IP_VERSION = 4
+    CIDR = "192.168.0.0/16"
+
+    def _create_keypair(self):
+        return self.conn.compute.create_keypair(
+            name=self.KP_NAME
+        )
+
+    def _delete_keypair(self, key_pair):
+        return self.conn.compute.delete_keypair(
+            keypair=key_pair
+        )
+
+    def _create_sec_group(self):
+        return self.conn.network.create_security_group(
+            name=self.SG_NAME
+        )
+
+    def _delete_sec_group(self, sec_group):
+        return self.conn.network.delete_security_group(
+            security_group=sec_group
+        )
+
+    def _create_network(self):
+        return self.conn.network.create_network(
+            name=self.NETWORK_NAME
+        )
+
+    def _delete_network(self, network):
+        return self.conn.network.delete_network(
+            network=network
+        )
+
+    def _create_subnet(self, network_id):
+        return self.conn.network.create_subnet(
+            name=self.SUBNET_NAME,
+            network_id=network_id,
+            ip_version=self.IP_VERSION,
+            cidr=self.CIDR
+        )
+
+    def _delete_subnet(self, subnet):
+        return self.conn.network.delete_subnet(
+            subnet=subnet
+        )
+
+    def _create_router(self, subnet_id):
+        router = self.conn.network.create_router(
+            name=self.ROUTER_NAME
+        )
+        self.conn.network.add_interface_to_router(
+            router=router,
+            subnet_id=subnet_id
+        )
+        return router
+
+    def _delete_router(self, router, subnet_id):
+        self.conn.network.remove_interface_from_router(
+            router=router,
+            subnet_id=subnet_id
+        )
+        return self.conn.network.delete_router(
+            router=router
+        )
+
+    def create_test_infra(self):
+        key_pair = self._create_keypair()
+        sec_group = self._create_sec_group()
+        network = self._create_network()
+        subnet = self._create_subnet(network.id)
+        router = self._create_router(subnet.id)
+        return {
+            "key_pair_id": key_pair.id,
+            "sec_group_id": sec_group.id,
+            "network_id": network.id,
+            "subnet_id": subnet.id,
+            "router_id": router.id
+        }
+
+    def delete_test_infra(self, infra: dict):
+        router = self.conn.network.get_router(infra.get("router_id"))
+        subnet = self.conn.network.get_subnet(infra.get("subnet_id"))
+        network = self.conn.network.get_network(infra.get("network_id"))
+        sec_group = self.conn.network.get_security_group(
+            infra.get("sec_group_id")
+        )
+        key_pair = self.conn.compute.get_keypair(infra.get("key_pair_id"))
+        if router:
+            self._delete_router(router, subnet.id)
+        if subnet:
+            self._delete_subnet(subnet)
+        if network:
+            self._delete_network(network)
+        if sec_group:
+            self._delete_sec_group(sec_group)
+        if key_pair:
+            self._delete_keypair(key_pair)
+
+    def setUp(self):
+        test_timeout = 3 * int(os.environ.get('OS_TEST_TIMEOUT'))
+        try:
+            self.useFixture(
+                fixtures.EnvironmentVariable(
+                    'OS_TEST_TIMEOUT', str(test_timeout)))
+        except ValueError:
+            pass
+        super(BaseASTest, self).setUp()
+        self.infra = self.create_test_infra()
+
+    def tearDown(self):
+        try:
+            self.delete_test_infra(self.infra)
+        except exceptions.SDKException as e:
+            _logger.warning('Got exception during clearing resources %s'
+                            % e.message)
+        finally:
+            super(BaseASTest, self).tearDown()

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/base.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/base.py
@@ -145,5 +145,4 @@ class BaseASTest(base.BaseFunctionalTest):
         except exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(BaseASTest, self).tearDown()
+        super(BaseASTest, self).tearDown()

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -140,8 +140,7 @@ class TestInstance(base.BaseASTest):
         try:
             self._deinitialize_as_group_with_instance()
         except exceptions.SDKException as e:
-            _logger.warning('Got exception during clearing '
-                                         'resources %s'
+            _logger.warning('Got exception during clearing resources %s'
                             % e.message)
         finally:
             super(TestInstance, self).tearDown()

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -90,7 +90,7 @@ class TestInstance(base.BaseASTest):
             group=as_group
         )
         self.conn.auto_scaling.wait_for_delete_group(
-            group=as_group,wait=timeout)
+            group=as_group, wait=timeout)
 
     def _wait_for_instance(self, as_group):
         timeout = int(os.environ.get('OS_TEST_TIMEOUT'))

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -84,11 +84,13 @@ class TestInstance(base.BaseASTest):
         return self.conn.auto_scaling.wait_for_group(as_group)
 
     def _delete_as_group(self, as_group):
+        timeout = 2 * int(os.environ.get('OS_TEST_TIMEOUT'))
         self.conn.auto_scaling.pause_group(as_group)
         self.conn.auto_scaling.delete_group(
             group=as_group
         )
-        self.conn.auto_scaling.wait_for_delete_group(as_group)
+        self.conn.auto_scaling.wait_for_delete_group(
+            group=as_group,wait=timeout)
 
     def _wait_for_instance(self, as_group):
         timeout = int(os.environ.get('OS_TEST_TIMEOUT'))
@@ -103,7 +105,7 @@ class TestInstance(base.BaseASTest):
                 return self.conn.auto_scaling.wait_for_instance(instances[0])
 
     def _delete_instance(self, instance):
-        timeout = int(os.environ.get('OS_TEST_TIMEOUT'))
+        timeout = 2 * int(os.environ.get('OS_TEST_TIMEOUT'))
         self.conn.auto_scaling.remove_instance(
             instance=instance,
             delete_instance=True

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -9,31 +9,23 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import uuid
+
 import os
+import uuid
 
-import fixtures
-import openstack
-
-from openstack import utils
+from openstack import exceptions
 from openstack import _log
+from openstack import utils
 
-from otcextensions.tests.functional import base
+from otcextensions.tests.functional.sdk.auto_scaling.v1 import base
 
 _logger = _log.setup_logging('openstack')
 
+class TestInstance(base.BaseASTest):
 
-class TestInstance(base.BaseFunctionalTest):
     UUID = uuid.uuid4().hex[:9]
-    NETWORK_NAME = "test-network-" + UUID
-    SUBNET_NAME = "test-subnet-" + UUID
-    ROUTER_NAME = "test-router-" + UUID
     AS_GROUP_NAME = "test-as-group-" + UUID
     AS_CONFIG_NAME = "test-as-config-" + UUID
-    SG_NAME = "test-sec-group-" + UUID
-    KP_NAME = "test-kp-" + UUID
-    IP_VERSION = 4
-    CIDR = "192.168.0.0/16"
     DESIRE_INSTANCE_NUMBER = 1
     MIN_INSTANCE_NUMBER = 0
     MAX_INSTANCE_NUMBER = 1
@@ -42,67 +34,6 @@ class TestInstance(base.BaseFunctionalTest):
     DISK_SIZE = 4
     DISK_VOL_TYPE = "SATA"
     DISK_TYPE = "SYS"
-
-    def _create_keypair(self):
-        return self.conn.compute.create_keypair(
-            name=self.KP_NAME
-        )
-
-    def _delete_keypair(self, key_pair):
-        return self.conn.compute.delete_keypair(
-            keypair=key_pair
-        )
-
-    def _create_sec_group(self):
-        return self.conn.network.create_security_group(
-            name=self.SG_NAME
-        )
-
-    def _delete_sec_group(self, sec_group):
-        return self.conn.network.delete_security_group(
-            security_group=sec_group
-        )
-
-    def _create_network(self):
-        return self.conn.network.create_network(
-            name=self.NETWORK_NAME
-        )
-
-    def _delete_network(self, network):
-        return self.conn.network.delete_network(
-            network=network
-        )
-
-    def _create_subnet(self, network_id):
-        return self.conn.network.create_subnet(
-            name=self.SUBNET_NAME,
-            network_id=network_id,
-            ip_version=self.IP_VERSION,
-            cidr=self.CIDR
-        )
-
-    def _delete_subnet(self, subnet):
-        return self.conn.network.delete_subnet(
-            subnet=subnet
-        )
-
-    def _create_router(self, subnet_id):
-        rtr = self.conn.network.create_router(
-            name=self.ROUTER_NAME
-        )
-        return self.conn.network.add_interface_to_router(
-            router=rtr,
-            subnet_id=subnet_id
-        )
-
-    def _delete_router(self, router, subnet_id):
-        self.conn.network.remove_interface_from_router(
-            router=router,
-            subnet_id=subnet_id
-        )
-        return self.conn.network.delete_router(
-            router=router
-        )
 
     def _get_image_id(self):
         image = self.conn.compute.find_image(
@@ -170,7 +101,7 @@ class TestInstance(base.BaseFunctionalTest):
             if len(instances) == self.MAX_INSTANCE_NUMBER and instances[0].id:
                 return self.conn.auto_scaling.wait_for_instance(instances[0])
 
-    def _delete_instance(self, instance, as_group):
+    def _delete_instance(self, instance):
         timeout = int(os.environ.get('OS_TEST_TIMEOUT'))
         self.conn.auto_scaling.remove_instance(
             instance=instance,
@@ -182,70 +113,51 @@ class TestInstance(base.BaseFunctionalTest):
         )
 
     def _initialize_as_group_with_instance(self):
-        self.key_pair = self._create_keypair()
-        self.sec_group = self._create_sec_group()
-        self.network = self._create_network()
-        self.subnet = self._create_subnet(self.network.id)
-        self.router = self._create_router(self.subnet.id)
         self.as_config = self._create_as_config(
-            self._get_image_id(), self.sec_group.id
+            self._get_image_id(), self.infra.get("sec_group_id")
         )
         self.as_group = self._create_as_group(
-            self.as_config.id, self.router['id'], self.network.id
+            self.as_config.id, self.infra.get("router_id"),
+            self.infra.get("network_id")
         )
-        self.instance = self._wait_for_instance(
+        self.as_instance = self._wait_for_instance(
             self.as_group
         )
 
     def _deinitialize_as_group_with_instance(self):
-        if self.instance:
-            self._delete_instance(self.instance, self.as_group)
+        if self.as_instance:
+            self._delete_instance(self.as_instance)
         if self.as_group:
             self._delete_as_group(self.as_group)
         if self.as_config:
             self._delete_as_config(self.as_config)
-        if self.router:
-            self._delete_router(self.router, self.subnet.id)
-        if self.subnet:
-            self._delete_subnet(self.subnet)
-        if self.network:
-            self._delete_network(self.network)
-        if self.sec_group:
-            self._delete_sec_group(self.sec_group)
-        if self.key_pair:
-            self._delete_keypair(self.key_pair)
 
     def setUp(self):
-        test_timeout = 3 * int(os.environ.get('OS_TEST_TIMEOUT'))
-        try:
-            self.useFixture(
-                fixtures.EnvironmentVariable(
-                    'OS_TEST_TIMEOUT', str(test_timeout)))
-        except ValueError:
-            pass
         super(TestInstance, self).setUp()
         self._initialize_as_group_with_instance()
 
     def tearDown(self):
-        super(TestInstance, self).tearDown()
         try:
             self._deinitialize_as_group_with_instance()
-        except openstack.exceptions.SDKException as e:
-            _logger.warning('Got exception during clearing resources %s'
+        except exceptions.SDKException as e:
+            _logger.warning('Got exception during clearing '
+                                         'resources %s'
                             % e.message)
+        finally:
+            super(TestInstance, self).tearDown()
 
     def test_find_instance_by_id(self):
         result = self.conn.auto_scaling.find_instance(
-            name_or_id=self.instance.id,
+            name_or_id=self.as_instance.id,
             group=self.as_group
         )
         self.assertIsNotNone(result)
-        self.assertEqual(self.instance.id, result.id)
+        self.assertEqual(self.as_instance.id, result.id)
 
     def test_find_instance_by_name(self):
         result = self.conn.auto_scaling.find_instance(
-            name_or_id=self.instance.name,
+            name_or_id=self.as_instance.name,
             group=self.as_group
         )
         self.assertIsNotNone(result)
-        self.assertEqual(self.instance.name, result.name)
+        self.assertEqual(self.as_instance.name, result.name)

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -21,6 +21,7 @@ from otcextensions.tests.functional.sdk.auto_scaling.v1 import base
 
 _logger = _log.setup_logging('openstack')
 
+
 class TestInstance(base.BaseASTest):
 
     UUID = uuid.uuid4().hex[:9]

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -143,8 +143,7 @@ class TestInstance(base.BaseASTest):
         except exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(TestInstance, self).tearDown()
+        super(TestInstance, self).tearDown()
 
     def test_find_instance_by_id(self):
         result = self.conn.auto_scaling.find_instance(

--- a/otcextensions/tests/functional/sdk/dms/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/dms/v1/test_instance.py
@@ -77,7 +77,6 @@ class TestInstance(base.BaseFunctionalTest):
         self.instances.append(self.instance)
 
     def tearDown(self):
-        super(TestInstance, self).tearDown()
         try:
             for instance in self.instances:
                 if instance.id:
@@ -90,7 +89,9 @@ class TestInstance(base.BaseFunctionalTest):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        self._deinitialize_network()
+        finally:
+            self._deinitialize_network()
+            super(TestInstance, self).tearDown()
 
     def test_list(self):
         self.all_instances = list(self.conn.dms.instances())

--- a/otcextensions/tests/functional/sdk/dms/v1/test_message.py
+++ b/otcextensions/tests/functional/sdk/dms/v1/test_message.py
@@ -56,8 +56,7 @@ class TestMessage(base.BaseFunctionalTest):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(TestMessage, self).tearDown()
+        super(TestMessage, self).tearDown()
 
     def test_list(self):
         self.queues = list(self.conn.dms.queues())

--- a/otcextensions/tests/functional/sdk/dms/v1/test_message.py
+++ b/otcextensions/tests/functional/sdk/dms/v1/test_message.py
@@ -49,7 +49,6 @@ class TestMessage(base.BaseFunctionalTest):
         self.groups.append(self.group)
 
     def tearDown(self):
-        super(TestMessage, self).tearDown()
         try:
             for queue in self.queues:
                 if queue.id:
@@ -57,6 +56,8 @@ class TestMessage(base.BaseFunctionalTest):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
+        finally:
+            super(TestMessage, self).tearDown()
 
     def test_list(self):
         self.queues = list(self.conn.dms.queues())

--- a/otcextensions/tests/functional/sdk/dms/v1/test_queue.py
+++ b/otcextensions/tests/functional/sdk/dms/v1/test_queue.py
@@ -40,8 +40,7 @@ class TestQueue(base.BaseFunctionalTest):
         except exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(TestQueue, self).tearDown()
+        super(TestQueue, self).tearDown()
 
     def test_list(self):
         self.queues = list(self.conn.dms.queues())

--- a/otcextensions/tests/functional/sdk/dms/v1/test_queue.py
+++ b/otcextensions/tests/functional/sdk/dms/v1/test_queue.py
@@ -33,7 +33,6 @@ class TestQueue(base.BaseFunctionalTest):
         self.queues.append(self.queue)
 
     def tearDown(self):
-        super(TestQueue, self).tearDown()
         try:
             for queue in self.queues:
                 if queue.id:
@@ -41,6 +40,8 @@ class TestQueue(base.BaseFunctionalTest):
         except exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
+        finally:
+            super(TestQueue, self).tearDown()
 
     def test_list(self):
         self.queues = list(self.conn.dms.queues())

--- a/otcextensions/tests/functional/sdk/dns/v2/test_floatingips.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_floatingips.py
@@ -33,11 +33,11 @@ class TestFloatingIps(TestDns):
         )
 
     def tearDown(self):
-        super(TestFloatingIps, self).tearDown()
         self.client.unset_floating_ip(
             floating_ip=self.floatingip,
         )
         self.conn.network.delete_ip(self.floating_ip)
+        super(TestFloatingIps, self).tearDown()
 
     def test_list_floatingips(self):
         ips = self.client.floating_ips()

--- a/otcextensions/tests/functional/sdk/dns/v2/test_nameservers.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_nameservers.py
@@ -34,7 +34,6 @@ class TestNameservers(TestDns):
         self.zones.append(self.zone)
 
     def tearDown(self):
-        super(TestNameservers, self).tearDown()
         try:
             for zone in self.zones:
                 if zone:
@@ -42,6 +41,8 @@ class TestNameservers(TestDns):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
+        finally:
+            super(TestNameservers, self).tearDown()
 
     def test_list_nameservers(self):
         nameservers = []

--- a/otcextensions/tests/functional/sdk/dns/v2/test_nameservers.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_nameservers.py
@@ -41,8 +41,7 @@ class TestNameservers(TestDns):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(TestNameservers, self).tearDown()
+        super(TestNameservers, self).tearDown()
 
     def test_list_nameservers(self):
         nameservers = []

--- a/otcextensions/tests/functional/sdk/dns/v2/test_recordsets.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_recordsets.py
@@ -35,7 +35,6 @@ class TestRecordsets(TestDns):
         self.zones.append(self.zone)
 
     def tearDown(self):
-        super(TestRecordsets, self).tearDown()
         try:
             for zone in self.zones:
                 if zone:
@@ -43,6 +42,8 @@ class TestRecordsets(TestDns):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
+        finally:
+            super(TestRecordsets, self).tearDown()
 
     def test_list_recordsets(self):
         rs = []

--- a/otcextensions/tests/functional/sdk/dns/v2/test_recordsets.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_recordsets.py
@@ -42,8 +42,7 @@ class TestRecordsets(TestDns):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(TestRecordsets, self).tearDown()
+        super(TestRecordsets, self).tearDown()
 
     def test_list_recordsets(self):
         rs = []

--- a/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
@@ -29,13 +29,14 @@ class TestZone(TestDns):
         super(TestZone, self).setUp()
 
     def tearDown(self):
-        super(TestZone, self).tearDown()
         try:
             if self.zone:
                 self.client.delete_zone(self.zone)
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
+        finally:
+            super(TestZone, self).tearDown()
 
     def _create_zone(self, zone_name=None, router_id=None, zone_type='public'):
         if zone_type != 'public' and router_id:

--- a/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
@@ -35,8 +35,7 @@ class TestZone(TestDns):
         except openstack.exceptions.SDKException as e:
             _logger.warning('Got exception during clearing resources %s'
                             % e.message)
-        finally:
-            super(TestZone, self).tearDown()
+        super(TestZone, self).tearDown()
 
     def _create_zone(self, zone_name=None, router_id=None, zone_type='public'):
         if zone_type != 'public' and router_id:

--- a/otcextensions/tests/functional/sdk/kms/v1/test_data_key.py
+++ b/otcextensions/tests/functional/sdk/kms/v1/test_data_key.py
@@ -29,7 +29,6 @@ class TestDataKey(base.BaseFunctionalTest):
         )
 
     def tearDown(self):
-        super(TestDataKey, self).tearDown()
         try:
             if self.cmk:
                 key = self.cmk
@@ -38,6 +37,8 @@ class TestDataKey(base.BaseFunctionalTest):
         except exceptions.SDKException as e:
             self.warning = _logger.warning('Got exception during '
                                            'clearing resources %s' % e.message)
+        finally:
+            super(TestDataKey, self).tearDown()
 
     def test_dek(self):
 

--- a/otcextensions/tests/functional/sdk/kms/v1/test_data_key.py
+++ b/otcextensions/tests/functional/sdk/kms/v1/test_data_key.py
@@ -37,8 +37,7 @@ class TestDataKey(base.BaseFunctionalTest):
         except exceptions.SDKException as e:
             self.warning = _logger.warning('Got exception during '
                                            'clearing resources %s' % e.message)
-        finally:
-            super(TestDataKey, self).tearDown()
+        super(TestDataKey, self).tearDown()
 
     def test_dek(self):
 


### PR DESCRIPTION
Moving parent tearDown to the end of tearDown methods. This allows resources to be released in the correct sequence.