### PR TITLE
pin sphinx

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,8 @@ docutils>=0.11 # OSI-Approved Open Source, Public Domain
 beautifulsoup4>=4.6.0 # MIT
 reno>=3.1.0 # Apache-2.0
 otcdocstheme # Apache-2.0
-sphinx>=2.0.0,!=2.1.0 # BSD
+#sphinx>=2.0.0,!=2.1.0 # BSD
+sphinx==3.5.4 # BSD
 sphinxcontrib-apidoc>=0.2.0 # BSD
 cliff!=2.9.0,>=2.8.0 # Apache-2.0
 oslo.i18n>=3.15.3 # Apache-2.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,8 +26,6 @@ extensions = [
 ]
 
 # openstackdocstheme options
-#otcdocs_repo_name = 'opentelekomcloud/python-otcextensions'
-html_last_updated_fmt = '%Y-%m-%d %H:%M'
 html_theme = 'otcdocs'
 
 # TODO(shade) Set this to true once the build-openstack-sphinx-docs job is

--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -25,7 +25,7 @@ extensions = [
 
 # openstackdocstheme options
 otcdocs_repo = 'opentelekomcloud/python-otcextensions'
-html_last_updated_fmt = '%Y-%m-%d %H:%M'
+otcdocs_bug_project = 'opentelekomcloud/python-otcextensions'
 html_theme = 'otcdocs'
 
 # TODO(shade) Set this to true once the build-openstack-sphinx-docs job is


### PR DESCRIPTION
Reno jobs in Zuul are not using constraints. This leads to double header
on the pages (due to another Sphinx version).
