### PR TITLE
Fix CES service metric namings

### DIFF
--- a/otcextensions/sdk/cce/v3/_proxy.py
+++ b/otcextensions/sdk/cce/v3/_proxy.py
@@ -11,7 +11,6 @@
 # under the License.
 from urllib import parse
 
-
 from openstack import proxy
 from openstack import resource
 

--- a/otcextensions/sdk/ces/v1/_proxy.py
+++ b/otcextensions/sdk/ces/v1/_proxy.py
@@ -22,6 +22,10 @@ class Proxy(proxy.Proxy):
 
     skip_discovery = True
 
+    def _extract_name(self, url, service_type=None, project_id=None):
+        return super()._extract_name(
+            url.lower(), service_type=service_type, project_id=project_id)
+
     # ======== Alarms ========
     def alarms(self, **query):
         """Return a generator of alarms

--- a/otcextensions/tests/unit/sdk/ces/v1/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/ces/v1/test_proxy.py
@@ -9,27 +9,14 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+from openstack.tests.unit import test_proxy_base
 
 from otcextensions.sdk.ces.v1 import _proxy
 from otcextensions.sdk.ces.v1 import alarm
 from otcextensions.sdk.ces.v1 import event_data
-from otcextensions.sdk.ces.v1 import metric_data
 from otcextensions.sdk.ces.v1 import metric
+from otcextensions.sdk.ces.v1 import metric_data
 from otcextensions.sdk.ces.v1 import quota
-
-from openstack.tests.unit import test_proxy_base
 
 
 class TestCesProxy(test_proxy_base.TestProxyBase):
@@ -84,3 +71,59 @@ class TestCesMetricData(TestCesProxy):
 class TestCesQuota(TestCesProxy):
     def test_quotas(self):
         self.verify_list(self.proxy.quotas, quota.Quota)
+
+
+class TestExtractName(TestCesProxy):
+
+    def test_extract_name(self):
+
+        self.assertEqual(
+            ['discovery'],
+            self.proxy._extract_name(
+                '/', project_id='123')
+        )
+        self.assertEqual(
+            ['discovery'],
+            self.proxy._extract_name(
+                '/V1.0/', project_id='123')
+        )
+        self.assertEqual(
+            ['alarms'],
+            self.proxy._extract_name(
+                '/V1.0/123/alarms', project_id='123')
+        )
+        self.assertEqual(
+            ['alarm'],
+            self.proxy._extract_name(
+                '/V1.0/123/alarms/some_id', project_id='123')
+        )
+        self.assertEqual(
+            ['alarm', 'action'],
+            self.proxy._extract_name(
+                '/V1.0/123/alarms/some_id/action', project_id='123')
+        )
+        self.assertEqual(
+            ['metrics'],
+            self.proxy._extract_name(
+                '/V1.0/123/metrics', project_id='123')
+        )
+        self.assertEqual(
+            ['metric-data'],
+            self.proxy._extract_name(
+                '/V1.0/123/metric-data?a=b', project_id='123')
+        )
+        self.assertEqual(
+            ['batch-query-metric-data'],
+            self.proxy._extract_name(
+                '/V1.0/123/batch-query-metric-data', project_id='123')
+        )
+        self.assertEqual(
+            ['event-data'],
+            self.proxy._extract_name(
+                '/V1.0/123/event-data', project_id='123')
+        )
+        self.assertEqual(
+            ['quotas'],
+            self.proxy._extract_name(
+                '/V1.0/123/quotas', project_id='123')
+        )

--- a/releasenotes/notes/fix-ces-metrics-f8a306b410114651.yaml
+++ b/releasenotes/notes/fix-ces-metrics-f8a306b410114651.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes metric naming for the CES service.


### PR DESCRIPTION
For CES service we do not emit proper metric names due to non-standard
URL containing /V1.0/
