### PR TITLE
Revert wait_for_delete_group method, use default sec_group for tests

### DIFF
--- a/otcextensions/sdk/auto_scaling/v1/_proxy.py
+++ b/otcextensions/sdk/auto_scaling/v1/_proxy.py
@@ -196,17 +196,7 @@ class Proxy(proxy.Proxy):
                  to status failed to occur in wait seconds.
         """
         group = self._get_resource(_group.Group, group)
-        for count in utils.iterate_timeout(
-                timeout=wait,
-                message="Timeout waiting for group to delete",
-                wait=interval
-        ):
-            try:
-                group = self._get(_group.Group, group)
-                if not group:
-                    return
-            except exceptions.NotFoundException:
-                return
+        return resource.wait_for_delete(self, group, interval, wait)
 
     # ======== Configurations ========
     def configs(self, **query):

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/base.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/base.py
@@ -28,7 +28,6 @@ class BaseASTest(base.BaseFunctionalTest):
     NETWORK_NAME = "test-as-network-" + UUID
     SUBNET_NAME = "test-as-subnet-" + UUID
     ROUTER_NAME = "test-as-router-" + UUID
-    SG_NAME = "test-as-sec-group-" + UUID
     KP_NAME = "test-as-kp-" + UUID
     IP_VERSION = 4
     CIDR = "192.168.0.0/16"
@@ -41,16 +40,6 @@ class BaseASTest(base.BaseFunctionalTest):
     def _delete_keypair(self, key_pair):
         return self.conn.compute.delete_keypair(
             keypair=key_pair
-        )
-
-    def _create_sec_group(self):
-        return self.conn.network.create_security_group(
-            name=self.SG_NAME
-        )
-
-    def _delete_sec_group(self, sec_group):
-        return self.conn.network.delete_security_group(
-            security_group=sec_group
         )
 
     def _create_network(self):
@@ -97,13 +86,11 @@ class BaseASTest(base.BaseFunctionalTest):
 
     def create_test_infra(self):
         key_pair = self._create_keypair()
-        sec_group = self._create_sec_group()
         network = self._create_network()
         subnet = self._create_subnet(network.id)
         router = self._create_router(subnet.id)
         return {
             "key_pair_id": key_pair.id,
-            "sec_group_id": sec_group.id,
             "network_id": network.id,
             "subnet_id": subnet.id,
             "router_id": router.id
@@ -113,9 +100,6 @@ class BaseASTest(base.BaseFunctionalTest):
         router = self.conn.network.get_router(infra.get("router_id"))
         subnet = self.conn.network.get_subnet(infra.get("subnet_id"))
         network = self.conn.network.get_network(infra.get("network_id"))
-        sec_group = self.conn.network.get_security_group(
-            infra.get("sec_group_id")
-        )
         key_pair = self.conn.compute.get_keypair(infra.get("key_pair_id"))
         if router:
             self._delete_router(router, subnet.id)
@@ -123,8 +107,6 @@ class BaseASTest(base.BaseFunctionalTest):
             self._delete_subnet(subnet)
         if network:
             self._delete_network(network)
-        if sec_group:
-            self._delete_sec_group(sec_group)
         if key_pair:
             self._delete_keypair(key_pair)
 

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_group.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_group.py
@@ -53,6 +53,13 @@ class TestGroup(base.BaseASTest):
         if image:
             return image.id
 
+    def _get_default_sec_group(self):
+        sec_group = self.conn.network.find_security_group(
+            name_or_id="default"
+        )
+        if sec_group:
+            return sec_group.id
+
     def _create_as_config(self, image_id, sec_group_id):
         config_attrs = {
             "name": self.AS_CONFIG_NAME,
@@ -144,11 +151,12 @@ class TestGroup(base.BaseASTest):
             group=as_group,
             force_delete=force_delete
         )
-        return self.conn.auto_scaling.wait_for_delete_group(
+        self.conn.auto_scaling.wait_for_delete_group(
             group=as_group,
             interval=5,
             wait=timeout
         )
+        return self.conn.auto_scaling.find_group(name_or_id=self.AS_GROUP_NAME)
 
     def _deinitialize_as_group(self):
         timeout = int(os.environ.get('OS_TEST_TIMEOUT'))
@@ -171,7 +179,7 @@ class TestGroup(base.BaseASTest):
     def test_02_create_as_group_with_instance(self):
         timeout = int(os.environ.get('OS_TEST_TIMEOUT'))
         self.as_config = self._create_as_config(self._get_image_id(),
-                                                self.infra.get("sec_group_id"))
+                                                self._get_default_sec_group())
         self.as_group = self._create_as_group(
             router_id=self.infra.get("router_id"),
             network_id=self.infra.get("network_id"),
@@ -187,7 +195,7 @@ class TestGroup(base.BaseASTest):
     def test_03_simple_delete_as_group(self):
         timeout = 2 * int(os.environ.get('OS_TEST_TIMEOUT'))
         self.as_config = self._create_as_config(self._get_image_id(),
-                                                self.infra.get("sec_group_id"))
+                                                self._get_default_sec_group())
         self.as_group = self._create_as_group(
             router_id=self.infra.get("router_id"),
             network_id=self.infra.get("network_id"),

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -43,6 +43,13 @@ class TestInstance(base.BaseASTest):
         if image:
             return image.id
 
+    def _get_default_sec_group(self):
+        sec_group = self.conn.network.find_security_group(
+            name_or_id="default"
+        )
+        if sec_group:
+            return sec_group.id
+
     def _create_as_config(self, image_id, sec_group_id):
         config_attrs = {
             "name": self.AS_CONFIG_NAME,
@@ -117,7 +124,7 @@ class TestInstance(base.BaseASTest):
 
     def _initialize_as_group_with_instance(self):
         self.as_config = self._create_as_config(
-            self._get_image_id(), self.infra.get("sec_group_id")
+            self._get_image_id(), self._get_default_sec_group()
         )
         self.as_group = self._create_as_group(
             self.as_config.id, self.infra.get("router_id"),

--- a/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
+++ b/otcextensions/tests/functional/sdk/auto_scaling/v1/test_instance.py
@@ -36,6 +36,18 @@ class TestInstance(base.BaseASTest):
     DISK_VOL_TYPE = "SATA"
     DISK_TYPE = "SYS"
 
+    def setUp(self):
+        super(TestInstance, self).setUp()
+        self._initialize_as_group_with_instance()
+
+    def tearDown(self):
+        try:
+            self._deinitialize_as_group_with_instance()
+        except exceptions.SDKException as e:
+            _logger.warning('Got exception during clearing resources %s'
+                            % e.message)
+        super(TestInstance, self).tearDown()
+
     def _get_image_id(self):
         image = self.conn.compute.find_image(
             name_or_id=self.IMAGE_NAME
@@ -141,18 +153,6 @@ class TestInstance(base.BaseASTest):
             self._delete_as_group(self.as_group)
         if self.as_config:
             self._delete_as_config(self.as_config)
-
-    def setUp(self):
-        super(TestInstance, self).setUp()
-        self._initialize_as_group_with_instance()
-
-    def tearDown(self):
-        try:
-            self._deinitialize_as_group_with_instance()
-        except exceptions.SDKException as e:
-            _logger.warning('Got exception during clearing resources %s'
-                            % e.message)
-        super(TestInstance, self).tearDown()
 
     def test_find_instance_by_id(self):
         result = self.conn.auto_scaling.find_instance(


### PR DESCRIPTION
In this PR wait_for_delete_group method was reverted, also default securitu group was used for tests, tests were fixed.