### PR TITLE
fix duplicating parameters in l7rule update

### DIFF
--- a/otcextensions/sdk/vlb/v3/_proxy.py
+++ b/otcextensions/sdk/vlb/v3/_proxy.py
@@ -824,5 +824,7 @@ class Proxy(proxy.Proxy):
         :rtype: :class:`~otcextensions.sdk.vlb.v3.l7_rule.L7Rule`
         """
         l7policyobj = self._get_resource(_l7policy.L7Policy, l7_policy)
+        if 'value' in attrs:
+            attrs['rule_value'] = attrs.pop('value')
         return self._update(_l7rule.L7Rule, l7rule,
                             l7policy_id=l7policyobj.id, **attrs)

--- a/otcextensions/sdk/vlb/v3/l7_rule.py
+++ b/otcextensions/sdk/vlb/v3/l7_rule.py
@@ -28,7 +28,7 @@ class L7Rule(resource.Resource):
     _query_mapping = resource.QueryParameters(
         'admin_state_up', 'compare_type', 'id',
         'invert', 'key', 'provisioning_status',
-        'type', 'value', is_admin_state_up='admin_state_up'
+        'type', 'rule_value', is_admin_state_up='admin_state_up'
     )
 
     # Properties
@@ -52,4 +52,4 @@ class L7Rule(resource.Resource):
     #: Specifies the match content.
     type = resource.Body('type')
     #: Specifies the value of the match item.
-    value = resource.Body('value')
+    rule_value = resource.Body('value')

--- a/otcextensions/tests/functional/sdk/vlb/v3/test_l7_rule.py
+++ b/otcextensions/tests/functional/sdk/vlb/v3/test_l7_rule.py
@@ -46,13 +46,19 @@ class TestL7Rule(TestVlb):
 
     def test_04_update_l7Rule(self):
         compare_type = 'STARTS_WITH'
+        rule_value = '/testchange.com'
         l7p = self.client.update_l7_rule(
             TestVlb.l7rule,
             TestVlb.l7policy,
             compare_type=compare_type,
         )
         self.assertEqual(l7p['compare_type'], compare_type)
-
+        l7p = self.client.update_l7_rule(
+            TestVlb.l7rule,
+            TestVlb.l7policy,
+            value=rule_value,
+        )
+        self.assertEqual(l7p['value'], rule_value)
         # cleanup
         self.client.delete_l7_rule(TestVlb.l7rule, TestVlb.l7policy)
         self.client.delete_l7_policy(TestVlb.l7policy)

--- a/otcextensions/tests/unit/sdk/vlb/v3/test_l7_rule.py
+++ b/otcextensions/tests/unit/sdk/vlb/v3/test_l7_rule.py
@@ -37,5 +37,5 @@ class TestLoadBalancer(base.TestCase):
     def test_make_it(self):
         sot = l7_rule.L7Rule(**EXAMPLE)
         self.assertEqual(EXAMPLE['compare_type'], sot.compare_type)
-        self.assertEqual(EXAMPLE['value'], sot.value)
+        self.assertEqual(EXAMPLE['value'], sot.rule_value)
         self.assertEqual(EXAMPLE['type'], sot.type)


### PR DESCRIPTION
`_update(self, resource_type, value, base_path=None, **attrs)`
Uses value parameter. 
And rule has parameter with same name. This cause duplicating exception. 
Closes #225 