### PR TITLE
Add `vpc_id` subnet list parameter

### DIFF
--- a/otcextensions/sdk/vpc/v1/subnet.py
+++ b/otcextensions/sdk/vpc/v1/subnet.py
@@ -32,6 +32,8 @@ class Subnet(resource.Resource):
     allow_delete = True
     allow_list = True
 
+    _query_mapping = resource.QueryParameters('vpc_id')
+
     # Properties
     project_id = resource.URI('project_id')
     description = resource.Body('description')

--- a/otcextensions/tests/functional/sdk/vpc/v1/test_subnet.py
+++ b/otcextensions/tests/functional/sdk/vpc/v1/test_subnet.py
@@ -33,7 +33,6 @@ class TestService(base.BaseFunctionalTest):
     def setUp(self):
         super().setUp()
 
-        self.client = self.conn.vpc
         attrs = {
             'name': 'test-vpc-' + self.seed,
             'cidr': '192.168.0.0/16'
@@ -98,7 +97,7 @@ class TestService(base.BaseFunctionalTest):
     def test_list_subnets(self):
         subnet = self._create_subnet()
 
-        subnets = list(self.conn.vpc.subnets())
+        subnets = list(self.conn.vpc.subnets(vpc_id=subnet.vpc_id))
         self.assertGreaterEqual(len(subnets), 1)
 
         self.assertIn(subnet, subnets)

--- a/releasenotes/notes/vpc-subnet-list-4fcb4fe4fecbdac2.yaml
+++ b/releasenotes/notes/vpc-subnet-list-4fcb4fe4fecbdac2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Allow passing ``vpc_id`` when listing subnets


### PR DESCRIPTION
Add support of `vpc_id` query parameter when listing subnets