### PR TITLE
Rename zuul docs template

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -27,9 +27,10 @@
 
 - project:
     merge-mode: squash-merge
+    default-branch: master
     templates:
       - publish-to-pypi
-      - publish-otc-docs-pti
+      - publish-otc-docs-hc-pti
       - release-notes-jobs
     check:
       jobs:


### PR DESCRIPTION
- use zuul jobs template publishing to helpcenter
- add default-branch to help when manually triggering jobs
