### PR TITLE
fix cbr vault resource

### DIFF
--- a/doc/source/sdk/resources/cbr/v3/vault.rst
+++ b/doc/source/sdk/resources/cbr/v3/vault.rst
@@ -27,8 +27,3 @@ The ``Vault`` class inherits from
 .. autoclass:: otcextensions.sdk.cbr.v3.vault.VolumeSpec
    :members:
 
-.. autoclass:: otcextensions.sdk.cbr.v3.vault.BindRuleSpec
-   :members:
-
-.. autoclass:: otcextensions.sdk.cbr.v3.vault.TagSpec
-   :members:

--- a/otcextensions/osclient/cbr/v3/vault.py
+++ b/otcextensions/osclient/cbr/v3/vault.py
@@ -72,8 +72,8 @@ def _add_resources_to_vault_obj(obj, data, columns):
 
 
 def _add_tags_to_vault_obj(obj, data, columns):
-    data += ('\n'.join((f'value={tag.value}, key={tag.key}'
-                        for tag in obj.tags)),)
+    data += ('\n'.join((f'value={tag["value"]}, key={tag["key"]}'
+                            for tag in obj.tags)),)
     columns = columns + ('tags',)
     return data, columns
 

--- a/otcextensions/osclient/cbr/v3/vault.py
+++ b/otcextensions/osclient/cbr/v3/vault.py
@@ -46,7 +46,7 @@ def _flatten_vault(obj):
         'charging_mode': obj.billing.charging_mode,
         'is_auto_pay': obj.billing.is_auto_pay,
         'is_auto_renew': obj.billing.is_auto_renew,
-        'bind_rules': obj.bind_rules.tags,
+        'bind_rules': obj.bind_rules["tags"],
         'resources': obj.resources,
         'tags': obj.tags,
     }
@@ -71,19 +71,21 @@ def _add_resources_to_vault_obj(obj, data, columns):
     return data, columns
 
 
-def _add_tags_to_vault_obj(obj, data, columns, name):
+def _add_tags_to_vault_obj(obj, data, columns):
     data += ('\n'.join((f'value={tag.value}, key={tag.key}'
-                            for tag in obj.tags)),)
-    columns = columns + (name,)
+                        for tag in obj.tags)),)
+    columns = columns + ('tags',)
     return data, columns
+
 
 def _add_bind_rules_to_vault_obj(obj, data, columns):
     """Add associated bind rules to column and data tuples
     """
     data += ('\n'.join((f'value={tag["value"]}, key={tag["key"]}'
-                        for tag in obj.bind_rules.tags)),)
+                        for tag in obj.bind_rules['tags'])),)
     columns = columns + ('bind_rules',)
     return data, columns
+
 
 def _add_associated_policy_to_vault_obj(data, columns):
     """Add associated resources to column and data tuples
@@ -256,8 +258,8 @@ class ShowVault(command.ShowOne):
                 obj, data, self.columns)
         if obj.tags:
             data, self.columns = _add_tags_to_vault_obj(
-                obj, data, self.columns, 'tags')
-        if obj.bind_rules.tags:
+                obj, data, self.columns)
+        if obj.bind_rules.get('tags'):
             data, self.columns = _add_bind_rules_to_vault_obj(
                 obj, data, self.columns)
         return self.columns, data
@@ -444,7 +446,7 @@ class CreateVault(command.ShowOne):
         if obj.resources:
             data, self.columns = _add_resources_to_vault_obj(
                 obj, data, self.columns)
-        if obj.bind_rules.tags:
+        if obj.bind_rules.get('tags'):
             data, self.columns = _add_bind_rules_to_vault_obj(
                 obj, data, self.columns)
         if obj.tags:
@@ -575,7 +577,7 @@ class UpdateVault(command.ShowOne):
         if obj.resources:
             data, self.columns = _add_resources_to_vault_obj(
                 obj, data, self.columns)
-        if obj.bind_rules.tags:
+        if obj.bind_rules.get('tags'):
             data, self.columns = _add_bind_rules_to_vault_obj(
                 obj, data, self.columns)
         if obj.tags:

--- a/otcextensions/osclient/cbr/v3/vault.py
+++ b/otcextensions/osclient/cbr/v3/vault.py
@@ -73,7 +73,7 @@ def _add_resources_to_vault_obj(obj, data, columns):
 
 def _add_tags_to_vault_obj(obj, data, columns):
     data += ('\n'.join((f'value={tag["value"]}, key={tag["key"]}'
-                            for tag in obj.tags)),)
+                        for tag in obj.tags)),)
     columns = columns + ('tags',)
     return data, columns
 
@@ -260,8 +260,9 @@ class ShowVault(command.ShowOne):
             data, self.columns = _add_tags_to_vault_obj(
                 obj, data, self.columns)
         if obj.bind_rules.get('tags'):
-            data, self.columns = _add_bind_rules_to_vault_obj(
-                obj, data, self.columns)
+            if obj.bind_rules['tags']:
+                data, self.columns = _add_bind_rules_to_vault_obj(
+                    obj, data, self.columns)
         return self.columns, data
 
 
@@ -422,6 +423,7 @@ class CreateVault(command.ShowOne):
         if parsed_args.backup_policy:
             attrs['backup_policy_id'] = parsed_args.backup_policy
         if parsed_args.bind_rule:
+            attrs['bind_rules'] = {'tags': []}
             attrs['bind_rules']['tags'] = _normalize_tags(
                 parsed_args.bind_rule)
         if parsed_args.description:
@@ -430,10 +432,6 @@ class CreateVault(command.ShowOne):
             attrs['enterprise_project_id'] = parsed_args.enterprise_project_id
         if parsed_args.auto_bind:
             attrs['auto_bind'] = parsed_args.auto_bind
-        if parsed_args.bind_rule:
-            attrs['bind_rules']['tags'] = _normalize_tags(
-                parsed_args.bind_rule
-            )
         if parsed_args.tag:
             attrs['tags'] = _normalize_tags(parsed_args.tag)
 
@@ -447,8 +445,9 @@ class CreateVault(command.ShowOne):
             data, self.columns = _add_resources_to_vault_obj(
                 obj, data, self.columns)
         if obj.bind_rules.get('tags'):
-            data, self.columns = _add_bind_rules_to_vault_obj(
-                obj, data, self.columns)
+            if obj.bind_rules['tags']:
+                data, self.columns = _add_bind_rules_to_vault_obj(
+                    obj, data, self.columns)
         if obj.tags:
             data, self.columns = _add_tags_to_vault_obj(
                 obj, data, self.columns)
@@ -578,8 +577,9 @@ class UpdateVault(command.ShowOne):
             data, self.columns = _add_resources_to_vault_obj(
                 obj, data, self.columns)
         if obj.bind_rules.get('tags'):
-            data, self.columns = _add_bind_rules_to_vault_obj(
-                obj, data, self.columns)
+            if obj.bind_rules['tags']:
+                data, self.columns = _add_bind_rules_to_vault_obj(
+                    obj, data, self.columns)
         if obj.tags:
             data, self.columns = _add_tags_to_vault_obj(
                 obj, data, self.columns)

--- a/otcextensions/sdk/cbr/v3/vault.py
+++ b/otcextensions/sdk/cbr/v3/vault.py
@@ -13,12 +13,6 @@ from openstack import resource
 from openstack import utils
 
 
-class BindRuleSpec(resource.Resource):
-    #: Properties
-    #: Filters automatically associated resources by tag
-    tags = resource.Body('tags', type=list, list_type=dict)
-
-
 class ResourceExtraInfoSpec(resource.Resource):
     #: Properties
     #: ID of the disk that is excluded from the backup
@@ -131,7 +125,7 @@ class Vault(resource.Resource):
     #: Billing spec
     billing = resource.Body('billing', type=BillingSpec)
     #: Rules for automatic association
-    bind_rules = resource.Body('bind_rules', type=BindRuleSpec)
+    bind_rules = resource.Body('bind_rules', type=dict)
     #: Creation time
     created_at = resource.Body('created_at')
     #: Description

--- a/otcextensions/sdk/cbr/v3/vault.py
+++ b/otcextensions/sdk/cbr/v3/vault.py
@@ -13,13 +13,21 @@ from openstack import resource
 from openstack import utils
 
 
+class VolumeSpec(resource.Resource):
+    #: Properties
+    #: Volume id
+    id = resource.Body('id')
+    #: OS type
+    os_version = resource.Body('os_version')
+
+
 class ResourceExtraInfoSpec(resource.Resource):
     #: Properties
     #: ID of the disk that is excluded from the backup
     exclude_volumes = resource.Body('exclude_volumes', type=list)
     #: Disk to be backed up
     include_volumes = resource.Body('include_volumes', type=list,
-                                    list_type=dict)
+                                    list_type=VolumeSpec)
 
 
 class ResourceSpec(resource.Resource):
@@ -44,6 +52,15 @@ class ResourceSpec(resource.Resource):
     type = resource.Body('type')
 
 
+class BillingExtraInfoSpec(resource.Resource):
+    #: Properties
+    #: Number of items in the aplication for creating vaults in the
+    #: combination mode
+    combined_order_ecs_num = resource.Body('combined_order_ecs_num')
+    #: ID of the application for creating vaults in combination
+    combined_order_id = resource.Body('combined_order_id')
+
+
 class BillingSpec(resource.Resource):
     #: Properties
     #: Allocated capacity in MB
@@ -61,7 +78,7 @@ class BillingSpec(resource.Resource):
     #: Redirection URL
     console_url = resource.Body('console_url')
     #: Billing extra info spec
-    extra_info = resource.Body('extra_info', type=dict)
+    extra_info = resource.Body('extra_info', type=BillingExtraInfoSpec)
     #: Scenario when an account is frozen
     frozen_scene = resource.Body('frozen_scene')
     #: Whether the fee is automatically deducted from the customers account

--- a/otcextensions/sdk/cbr/v3/vault.py
+++ b/otcextensions/sdk/cbr/v3/vault.py
@@ -13,38 +13,21 @@ from openstack import resource
 from openstack import utils
 
 
-class TagSpec (resource.Resource):
-    #: Properties
-    #: Tag key, up to 36 chars
-    key = resource.Body('key')
-    #: Tag value, up to 43 chars
-    value = resource.Body('value')
-
-
-class BindRuleSpec(resource.Resource):
+class BindRuleSpec(dict):
     #: Properties
     #: Filters automatically associated resources by tag
-    tags = resource.Body('tags', type=list, list_type=TagSpec)
+    tags = resource.Body('tags', type=list, list_type=dict)
 
 
-class VolumeSpec(resource.Resource):
-    #: Properties
-    #: Volume id
-    id = resource.Body('id')
-    #: OS type
-    os_version = resource.Body('os_version')
-
-
-class ResourceExtraInfoSpec(resource.Resource):
+class ResourceExtraInfoSpec(dict):
     #: Properties
     #: ID of the disk that is excluded from the backup
     exclude_volumes = resource.Body('exclude_volumes', type=list)
     #: Disk to be backed up
-    include_volumes = resource.Body('include_volumes', type=list,
-                                    list_type=VolumeSpec)
+    include_volumes = resource.Body('include_volumes', type=list, list_type=dict)
 
 
-class ResourceSpec(resource.Resource):
+class ResourceSpec(dict):
     #: Properties
     #: Number of backups
     backup_count = resource.Body('backup_count', type=int)
@@ -66,16 +49,7 @@ class ResourceSpec(resource.Resource):
     type = resource.Body('type')
 
 
-class BillingExtraInfoSpec(resource.Resource):
-    #: Properties
-    #: Number of items in the aplication for creating vaults in the
-    #: combination mode
-    combined_order_ecs_num = resource.Body('combined_order_ecs_num')
-    #: ID of the application for creating vaults in combination
-    combined_order_id = resource.Body('combined_order_id')
-
-
-class BillingSpec(resource.Resource):
+class BillingSpec(dict):
     #: Properties
     #: Allocated capacity in MB
     allocated = resource.Body('allocated', type=int)
@@ -92,7 +66,7 @@ class BillingSpec(resource.Resource):
     #: Redirection URL
     console_url = resource.Body('console_url')
     #: Billing extra info spec
-    extra_info = resource.Body('extra_info', type=BillingExtraInfoSpec)
+    extra_info = resource.Body('extra_info', type=dict)
     #: Scenario when an account is frozen
     frozen_scene = resource.Body('frozen_scene')
     #: Whether the fee is automatically deducted from the customers account
@@ -170,7 +144,7 @@ class Vault(resource.Resource):
     #: Associated Resources
     resources = resource.Body('resources', type=list, list_type=ResourceSpec)
     #: Tag list up to 10 key value pairs
-    tags = resource.Body('tags', type=list, list_type=TagSpec)
+    tags = resource.Body('tags', type=list, list_type=dict)
     #: User ID
     user_id = resource.Body('user_id')
 

--- a/otcextensions/sdk/cbr/v3/vault.py
+++ b/otcextensions/sdk/cbr/v3/vault.py
@@ -13,21 +13,22 @@ from openstack import resource
 from openstack import utils
 
 
-class BindRuleSpec(dict):
+class BindRuleSpec(resource.Resource):
     #: Properties
     #: Filters automatically associated resources by tag
     tags = resource.Body('tags', type=list, list_type=dict)
 
 
-class ResourceExtraInfoSpec(dict):
+class ResourceExtraInfoSpec(resource.Resource):
     #: Properties
     #: ID of the disk that is excluded from the backup
     exclude_volumes = resource.Body('exclude_volumes', type=list)
     #: Disk to be backed up
-    include_volumes = resource.Body('include_volumes', type=list, list_type=dict)
+    include_volumes = resource.Body('include_volumes', type=list,
+                                    list_type=dict)
 
 
-class ResourceSpec(dict):
+class ResourceSpec(resource.Resource):
     #: Properties
     #: Number of backups
     backup_count = resource.Body('backup_count', type=int)
@@ -49,7 +50,7 @@ class ResourceSpec(dict):
     type = resource.Body('type')
 
 
-class BillingSpec(dict):
+class BillingSpec(resource.Resource):
     #: Properties
     #: Allocated capacity in MB
     allocated = resource.Body('allocated', type=int)

--- a/otcextensions/tests/unit/osclient/cbr/v3/test_vault.py
+++ b/otcextensions/tests/unit/osclient/cbr/v3/test_vault.py
@@ -72,7 +72,7 @@ class TestVault(fakes.TestCBR):
             obj.billing.charging_mode,
             obj.billing.is_auto_pay,
             obj.billing.is_auto_renew,
-            obj.bind_rules.tags,
+            obj.bind_rules["tags"],
             obj.resources,
             obj.tags,
         )
@@ -110,7 +110,24 @@ class TestVault(fakes.TestCBR):
             ('value=val-tags, key=key-tags',)
         )
 
-        data, column = vault._add_tags_to_vault_obj(obj, data, column, 'tags')
+        data, column = vault._add_tags_to_vault_obj(obj, data, column)
+
+        self.assertEqual(data, verify_data)
+        self.assertEqual(column, verify_column)
+
+    def test_add_bind_rules_to_vault_output(self):
+        obj = fakes.FakeVault.create_one()
+
+        column = ()
+        data = ()
+        verify_column = (
+            'bind_rules',
+        )
+        verify_data = (
+            ('value=val-bind, key=key-bind',)
+        )
+
+        data, column = vault._add_bind_rules_to_vault_obj(obj, data, column)
 
         self.assertEqual(data, verify_data)
         self.assertEqual(column, verify_column)
@@ -348,14 +365,12 @@ class TestShowVault(fakes.TestCBR):
             self.object,
             self.data,
             self.columns,
-            'tags'
         )
 
-        self.data, self.columns = vault._add_tags_to_vault_obj(
+        self.data, self.columns = vault._add_bind_rules_to_vault_obj(
             self.object,
             self.data,
-            self.columns,
-            'bind_rules'
+            self.columns
         )
 
         self.assertEqual(self.columns, columns)
@@ -517,18 +532,16 @@ class TestCreateVault(fakes.TestCBR):
             self.columns
         )
 
-        self.data, self.columns = vault._add_tags_to_vault_obj(
+        self.data, self.columns = vault._add_bind_rules_to_vault_obj(
             self.object,
             self.data,
-            self.columns,
-            'bind_rules'
+            self.columns
         )
 
         self.data, self.columns = vault._add_tags_to_vault_obj(
             self.object,
             self.data,
-            self.columns,
-            'tags'
+            self.columns
         )
 
         self.assertEqual(self.columns, columns)
@@ -634,18 +647,16 @@ class TestUpdateVault(fakes.TestCBR):
             self.columns
         )
 
-        self.data, self.columns = vault._add_tags_to_vault_obj(
+        self.data, self.columns = vault._add_bind_rules_to_vault_obj(
             self.object,
             self.data,
-            self.columns,
-            'bind_rules'
+            self.columns
         )
 
         self.data, self.columns = vault._add_tags_to_vault_obj(
             self.object,
             self.data,
-            self.columns,
-            'tags'
+            self.columns
         )
 
         self.assertEqual(self.columns, columns)


### PR DESCRIPTION
change type of parameter 'bind_rules' from 'BindRules' to dict. It fixed wrong conversion when it passes to ansible collections (it returned empty list for 'tags' in 'bind_rule')