### PR TITLE
Some logical error fixes in server.py and backup.py

### DIFF
--- a/otcextensions/sdk/compute/v2/server.py
+++ b/otcextensions/sdk/compute/v2/server.py
@@ -34,7 +34,6 @@ class Server(server.Server):
         :param session: The session to use for making this request.
         :param tag: The tag as a string.
         """
-        session = self._connection.ecs
         url = utils.urljoin('servers', self.id,
                             'tags', 'action')
         body = {
@@ -57,7 +56,6 @@ class Server(server.Server):
         :param session: The session to use for making this request.
         :param tag: The tag as a string.
         """
-        session = self._connection.ecs
         url = utils.urljoin('servers', self.id,
                             'tags', 'action')
         body = {

--- a/otcextensions/sdk/rds/v3/backup.py
+++ b/otcextensions/sdk/rds/v3/backup.py
@@ -95,13 +95,13 @@ class Backup(_base.Resource):
         """
         if not self.allow_fetch:
             raise exceptions.MethodNotSupported(self, "fetch")
-            
+
         # Create request parameters
         request_params = {
             'instance_id': self.instance_id,
             'backup_id': self.id
         }
-        
+
         # Merge with additional params if provided
         request_params.update(params)
 

--- a/otcextensions/sdk/rds/v3/backup.py
+++ b/otcextensions/sdk/rds/v3/backup.py
@@ -105,8 +105,8 @@ class Backup(_base.Resource):
         # Merge with additional params if provided
         request_params.update(params)
 
-        query_params = self._query_mapping._transpose(params, self)
-        url = utils.urljoin(self.base_path) % params
+        query_params = self._query_mapping._transpose(request_params, self)
+        url = utils.urljoin(self.base_path) % request_params
 
         session = self._get_session(session)
         microversion = self._get_microversion(session, action='fetch')

--- a/otcextensions/sdk/rds/v3/backup.py
+++ b/otcextensions/sdk/rds/v3/backup.py
@@ -95,11 +95,16 @@ class Backup(_base.Resource):
         """
         if not self.allow_fetch:
             raise exceptions.MethodNotSupported(self, "fetch")
-
-        params = {
+            
+        # Create request parameters
+        request_params = {
             'instance_id': self.instance_id,
             'backup_id': self.id
         }
+        
+        # Merge with additional params if provided
+        request_params.update(params)
+
         query_params = self._query_mapping._transpose(params, self)
         url = utils.urljoin(self.base_path) % params
 

--- a/otcextensions/tests/unit/sdk/compute/v2/test_server.py
+++ b/otcextensions/tests/unit/sdk/compute/v2/test_server.py
@@ -56,8 +56,7 @@ class TestServer(base.TestCase):
             "action": "create",
             "tags": [{'key': 'a', 'value': 'b'}]
         }
-        self.sot._connection.ecs.post.assert_called_with(
-            url, json=body)
+        self.sess.post.assert_called_with(url, json=body)
 
     def test_remove_tag(self):
         # Let the translate pass through, that portion is tested elsewhere
@@ -72,5 +71,4 @@ class TestServer(base.TestCase):
             "action": "delete",
             "tags": [{'key': 'a', 'value': 'b'}]
         }
-        self.sot._connection.ecs.post.assert_called_with(
-            url, json=body)
+        self.sess.post.assert_called_with(url, json=body)


### PR DESCRIPTION
server.py: It appears that the session parameter is being overwritten in both the add_tag and remove_tag methods, therfore I would remove the lines that overwrites the session variable

test_server.py: The unit test failures are due to the tests expecting that self.sot._connection.ecs.post is called, but after our refactoring, the provided session's post method is the one being called instead.

backup.py: Don't overwrite the params argument, but merge the needed params (now declared as request_params) passed as an argument.