### PR TITLE
[OBS]: Folder creation and management fix

### DIFF
--- a/otcextensions/sdk/obs/v1/_proxy.py
+++ b/otcextensions/sdk/obs/v1/_proxy.py
@@ -362,6 +362,14 @@ class Proxy(sdk_proxy.Proxy):
         container = self._get_container_name(container=container)
         endpoint = self.get_container_endpoint(container)
 
+        # folder logic
+        if data is None and name[-1] == "/":
+            return self._create(_obj.Object, container=container,
+                                name=name,
+                                endpoint_override=endpoint,
+                                requests_auth=self._get_req_auth(endpoint),
+                                **headers)
+
         if data is not None:
             self.log.debug(
                 "uploading data to %(endpoint)s",

--- a/otcextensions/sdk/obs/v1/obj.py
+++ b/otcextensions/sdk/obs/v1/obj.py
@@ -254,6 +254,9 @@ class Object(_base.BaseResource):
             requires_id=True,
             prepend_key=prepend_key)
 
+        if self.id[-1] == "/":
+            request.url += "/"
+
         req_args = self._prepare_override_args(
             endpoint_override=endpoint_override,
             request_headers=request.headers,
@@ -265,6 +268,36 @@ class Object(_base.BaseResource):
             data=self.data,
             **req_args)
         self._translate_response(response)
+        return self
+
+    def delete(self, session, error_message=None,
+               endpoint_override=None, headers=None,
+               requests_auth=None, params=None):
+
+        if not self.allow_delete:
+            raise exceptions.MethodNotSupported(self, "delete")
+
+        request = self._prepare_request()
+        if self.id[-1] == "/":
+            request.url += "/"
+
+        session = self._get_session(session)
+
+        delete_args = self._prepare_override_args(
+            endpoint_override=endpoint_override,
+            request_headers=request.headers,
+            additional_headers=headers,
+            requests_auth=requests_auth)
+        if params:
+            delete_args['params'] = params
+
+        response = session.delete(request.url,
+                                  **delete_args)
+        kwargs = {}
+        if error_message:
+            kwargs['error_message'] = error_message
+
+        self._translate_response(response, has_body=False, **kwargs)
         return self
 
     def download(self, session, filename=None,

--- a/otcextensions/tests/functional/sdk/obs/v1/test_object.py
+++ b/otcextensions/tests/functional/sdk/obs/v1/test_object.py
@@ -22,6 +22,7 @@ class TestContainer(base.BaseFunctionalTest):
     uuid_v4 = uuid.uuid4().hex[:8]
     bucket_name = 'obs-test-' + uuid_v4
     object_name = f'obs{uuid_v4}.object'
+    folder_name = f'folder{uuid_v4}/'
     data = str(uuid.uuid4())
     container = None
     object = None
@@ -39,6 +40,10 @@ class TestContainer(base.BaseFunctionalTest):
             name=self.object_name,
             data=self.data
         )
+        self.folder = self.client.create_object(
+            container=self.container,
+            name=self.folder_name
+        )
 
     def test_01_get_object(self):
         object = self.client.get_object(
@@ -52,7 +57,9 @@ class TestContainer(base.BaseFunctionalTest):
             self.object_name,
             container=self.container
         )
+
         self.assertIsNotNone(object)
         self.assertIsNotNone(object.etag)
         self.client.delete_object(self.object)
+        self.client.delete_object(self.folder)
         self.client.delete_container(self.container)


### PR DESCRIPTION
FIx folder creation and deletion for OBS.
Includes:
- create_object
- delete_object

Refers to: #401

### Unit tests
  pep8: OK (33.97=setup[20.29]+cmd[12.12,1.56] seconds)
  py3: OK (24.78=setup[15.43]+cmd[9.13,0.22] seconds)
  congratulations :) (58.84 seconds)