### PR TITLE
Async job entities

### DIFF
--- a/otcextensions/sdk/imsv1/v1/async_job.py
+++ b/otcextensions/sdk/imsv1/v1/async_job.py
@@ -13,10 +13,12 @@
 
 from openstack import resource
 
+
 class AsyncJobEntities(resource.Resource):
     image_id = resource.Body('image_id')
     image_name = resource.Body('image_name')
     process_percent = resource.Body('process_percent')
+
 
 class AsyncJob(resource.Resource):
     allow_fetch = True

--- a/otcextensions/sdk/imsv1/v1/async_job.py
+++ b/otcextensions/sdk/imsv1/v1/async_job.py
@@ -13,6 +13,10 @@
 
 from openstack import resource
 
+class AsyncJobEntities(resource.Resource):
+    image_id = resource.Body('image_id')
+    image_name = resource.Body('image_name')
+    process_percent = resource.Body('process_percent')
 
 class AsyncJob(resource.Resource):
     allow_fetch = True
@@ -26,7 +30,7 @@ class AsyncJob(resource.Resource):
     end_time = resource.Body('end_time')
     error_code = resource.Body('error_code')
     fail_reason = resource.Body('fail_reason')
-    entities = resource.Body('entities', type=list)
+    entities = resource.Body('entities', type=AsyncJobEntities)
 
     def get(self, session, prepend_key=False, base_path=None):
         # Overriden here to override prepend_key default value

--- a/releasenotes/notes/ims-async-job-entities-a7495e1930509f33.yaml
+++ b/releasenotes/notes/ims-async-job-entities-a7495e1930509f33.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The AsyncJobEntities type allows easier access to the entities of an IMS job.


### PR DESCRIPTION
The AsyncJobEntities type allows easier access to the job entities. E.g.:
```
job = conn.imsv1.get_async_job(job_id)
job.entities.image_id
```