### PR TITLE
[KMS] Fix typo in example

### DIFF
--- a/examples/kms/decrypt_datakey.py
+++ b/examples/kms/decrypt_datakey.py
@@ -21,7 +21,7 @@ conn = openstack.connect(cloud='otc')
 
 data = conn.kms.decrypt_datakey(
     cmk='cmk_id',
-    cypher_text='64_bit_cypher',
-    datakey_cypher_length='64'
+    cipher_text='64_bit_cipher',
+    datakey_cipher_length='64'
 )
 print(data)


### PR DESCRIPTION
Thank you for this great library !
While working on the KMS, I spotted this typo in the example displayed [here](https://python-otcextensions.readthedocs.io/en/latest/sdk/guides/kms.html#decrypt-datakey).