### PR TITLE
rm failing _extract_name method from vpc

### DIFF
--- a/otcextensions/common/utils.py
+++ b/otcextensions/common/utils.py
@@ -159,13 +159,11 @@ def extract_url_parts(url: str, project_id: str) -> list:
     url_parts = [x for x in path.split('/') if x != project_id]
 
     # Exclude parts that are version identifiers
-    url_parts = list(
-        filter(
-            lambda x: not any(
-                c.isdigit() for c in x[1:]) and (x[0].lower() != 'v'),
-            url_parts
-        )
-    )
+    url_parts = list(filter(
+        lambda x: len(x) > 0 and not
+        (x.lower().startswith('v') and x[1:].isdigit()),
+        url_parts
+    ))
 
     # Strip out empty or None segments and return
     return [part for part in url_parts if part]

--- a/otcextensions/sdk/vpc/v1/_proxy.py
+++ b/otcextensions/sdk/vpc/v1/_proxy.py
@@ -12,6 +12,7 @@
 from openstack import exceptions
 from openstack import proxy
 
+from otcextensions.common.utils import extract_url_parts
 from otcextensions.sdk.vpc.v1 import bandwidth as _bandwidth
 from otcextensions.sdk.vpc.v1 import peering as _peering
 from otcextensions.sdk.vpc.v1 import route as _route
@@ -30,6 +31,9 @@ class PublicInfo:
 
 class Proxy(proxy.Proxy):
     skip_discovery = True
+
+    def _extract_name(self, url, service_type=None, project_id=None):
+        return extract_url_parts(url, project_id)
 
     # ======== Bandwidth ========
     def assign_bandwidth(self, **attrs):

--- a/otcextensions/sdk/vpc/v1/_proxy.py
+++ b/otcextensions/sdk/vpc/v1/_proxy.py
@@ -12,7 +12,6 @@
 from openstack import exceptions
 from openstack import proxy
 
-from otcextensions.common.utils import extract_url_parts
 from otcextensions.sdk.vpc.v1 import bandwidth as _bandwidth
 from otcextensions.sdk.vpc.v1 import peering as _peering
 from otcextensions.sdk.vpc.v1 import route as _route
@@ -31,9 +30,6 @@ class PublicInfo:
 
 class Proxy(proxy.Proxy):
     skip_discovery = True
-
-    def _extract_name(self, url, service_type=None, project_id=None):
-        return extract_url_parts(url, project_id)
 
     # ======== Bandwidth ========
     def assign_bandwidth(self, **attrs):

--- a/otcextensions/tests/unit/sdk/vpc/v1/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/vpc/v1/test_proxy.py
@@ -235,3 +235,17 @@ class TestSubnet(TestVpcProxy):
                 'ignore_missing': True,
                 'base_path': subnet.vpc_subnet_base_path('vpc'),
             })
+
+class TestExtractName(TestVpcProxy):
+
+    def test_extract_name(self):
+
+        self.assertEqual(
+            ['vpcs'],
+            self.proxy._extract_name('/v1/123/vpcs', project_id='123')
+        )
+        self.assertEqual(
+            [],
+            self.proxy._extract_name(
+                '/', project_id='123')
+        )

--- a/otcextensions/tests/unit/sdk/vpc/v1/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/vpc/v1/test_proxy.py
@@ -236,10 +236,10 @@ class TestSubnet(TestVpcProxy):
                 'base_path': subnet.vpc_subnet_base_path('vpc'),
             })
 
+
 class TestExtractName(TestVpcProxy):
 
     def test_extract_name(self):
-
         self.assertEqual(
             ['vpcs'],
             self.proxy._extract_name('/v1/123/vpcs', project_id='123')


### PR DESCRIPTION
Epmon failing, fixed name extraction for empty url