### PR TITLE
[Feat.] FunctionGraph templates and logs

### DIFF
--- a/.stestr.blacklist.functional
+++ b/.stestr.blacklist.functional
@@ -37,4 +37,6 @@ otcextensions.tests.functional.osclient.identity.v3*
 otcextensions.tests.functional.sdk.dms.v1.test_cleanup
 otcextensions.tests.functional.sdk.nat.v2.test_cleanup
 otcextensions.tests.functional.sdk.function_graph.v2.test_dependency*
+otcextensions.tests.functional.sdk.function_graph.v2.test_log*
+otcextensions.tests.functional.sdk.function_graph.v2.test_template*
 otcextensions.tests.functional.sdk.apig.v2.test_gateway

--- a/doc/source/sdk/guides/function_graph.rst
+++ b/doc/source/sdk/guides/function_graph.rst
@@ -295,3 +295,27 @@ This API is used to query the alias of a function version.
 
 .. literalinclude:: ../examples/function_graph/list_metrics.py
    :lines: 16-24
+
+Querying the Log Group and Stream of a Function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is used to query the LTS log group and stream settings of a function.
+
+.. literalinclude:: ../examples/function_graph/get_lts_log_detail.py
+   :lines: 16-35
+
+Enabling Log Reporting to LTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is used to enable log reporting to LTS.
+
+.. literalinclude:: ../examples/function_graph/enable_lts_log.py
+   :lines: 16-23
+
+Querying a Specified Function Template
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is used to query a specified function template.
+
+.. literalinclude:: ../examples/function_graph/get_template.py
+   :lines: 16-26

--- a/doc/source/sdk/proxies/function_graph.rst
+++ b/doc/source/sdk/proxies/function_graph.rst
@@ -73,3 +73,17 @@ Metrics
 .. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
   :noindex:
   :members: metrics, function_metrics
+
+Logs
+^^^^
+
+.. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
+  :noindex:
+  :members: get_lts_log_settings, enable_lts_log
+
+Templates
+^^^^^^^^^
+
+.. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
+  :noindex:
+  :members: get_template

--- a/doc/source/sdk/resources/function_graph/index.rst
+++ b/doc/source/sdk/resources/function_graph/index.rst
@@ -12,3 +12,5 @@ FunctionGraph Resources
    v2/alias
    v2/version
    v2/metric
+   v2/log
+   v2/template

--- a/doc/source/sdk/resources/function_graph/v2/log.rst
+++ b/doc/source/sdk/resources/function_graph/v2/log.rst
@@ -1,0 +1,13 @@
+otcextensions.sdk.function_graph.v2.log
+=======================================
+
+.. automodule:: otcextensions.sdk.function_graph.v2.log
+
+The Log Class
+---------------
+
+The ``Log`` class inherits from
+:class:`~otcextensions.sdk.sdk_resource.Resource`.
+
+.. autoclass:: otcextensions.sdk.function_graph.v2.log.Log
+   :members:

--- a/doc/source/sdk/resources/function_graph/v2/template.rst
+++ b/doc/source/sdk/resources/function_graph/v2/template.rst
@@ -1,0 +1,13 @@
+otcextensions.sdk.function_graph.v2.template
+============================================
+
+.. automodule:: otcextensions.sdk.function_graph.v2.template
+
+The Template Class
+---------------
+
+The ``Template`` class inherits from
+:class:`~otcextensions.sdk.sdk_resource.Resource`.
+
+.. autoclass:: otcextensions.sdk.function_graph.v2.template.Template
+   :members:

--- a/doc/source/sdk/resources/function_graph/v2/template.rst
+++ b/doc/source/sdk/resources/function_graph/v2/template.rst
@@ -4,7 +4,7 @@ otcextensions.sdk.function_graph.v2.template
 .. automodule:: otcextensions.sdk.function_graph.v2.template
 
 The Template Class
----------------
+------------------
 
 The ``Template`` class inherits from
 :class:`~otcextensions.sdk.sdk_resource.Resource`.

--- a/examples/function_graph/enable_lts_log.py
+++ b/examples/function_graph/enable_lts_log.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Enable log reporting to LTS
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+conn.functiongraph.enable_lts_log()

--- a/examples/function_graph/get_lts_log_detail.py
+++ b/examples/function_graph/get_lts_log_detail.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Get lts log settings
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+func_attrs = {
+    'func_name': 'test-function',
+    'package': 'default',
+    'runtime': 'Python3.9',
+    'handler': 'index.handler',
+    'timeout': 30,
+    'memory_size': 128,
+    'code_type': 'inline',
+}
+fg = conn.functiongraph.create_function(**func_attrs)
+
+log = conn.functiongraph.get_lts_log_settings(fg)
+print(log)

--- a/examples/function_graph/get_template.py
+++ b/examples/function_graph/get_template.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Get template
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+template = conn.functiongraph.get_template(
+    template_id="41d5d9ca-cea3-4ba9-b866-e30c46f45f1f"
+)
+print(template)

--- a/otcextensions/sdk/function_graph/v2/_proxy.py
+++ b/otcextensions/sdk/function_graph/v2/_proxy.py
@@ -20,6 +20,8 @@ from otcextensions.sdk.function_graph.v2 import event as _event
 from otcextensions.sdk.function_graph.v2 import alias as _alias
 from otcextensions.sdk.function_graph.v2 import version as _version
 from otcextensions.sdk.function_graph.v2 import metric as _metric
+from otcextensions.sdk.function_graph.v2 import log as _log
+from otcextensions.sdk.function_graph.v2 import template as _t
 
 
 class Proxy(proxy.Proxy):
@@ -460,3 +462,48 @@ class Proxy(proxy.Proxy):
         func_urn = function.func_urn.rpartition(":")[0]
         base_path = f'/fgs/functions/{func_urn}/statistics/{period}'
         return self._list(_metric.Metric, base_path=base_path)
+
+    # ======== Log Methods ========
+
+    def get_lts_log_settings(self, function):
+        """Get log group and stream settings of a function.
+
+        :param function: The value can be the ID of a function or
+            a :class:`~otcextensions.sdk.function_graph.v2.function.Function`
+            instance.
+        :returns: instance of
+            :class:`~otcextensions.sdk.function_graph.v2.log.Log`
+        """
+        func = self._get_resource(_function.Function, function)
+        function_urn = func.func_urn.rpartition(":")[0]
+        return self._get(
+            _log.Log,
+            function_urn=function_urn,
+            requires_id=False
+        )
+
+    def enable_lts_log(self):
+        """Enable log reporting to LTS.
+
+        :returns: The created Log instance.
+        :rtype: :class:`~otcextensions.sdk.function_graph.v2.log.Log`
+        """
+        base_path = '/fgs/functions/enable-lts-logs'
+        return self._create(
+            _log.Log, base_path=base_path
+        )
+
+    # ======== Templates Methods ========
+
+    def get_template(self, template_id):
+        """Get one template by ID.
+
+        :param template_id: id of template
+        :returns: instance of
+            :class:`~otcextensions.sdk.function_graph.v2.template.Template`
+        """
+        return self._get(
+            _t.Template,
+            template_id=template_id,
+            requires_id=False
+        )

--- a/otcextensions/sdk/function_graph/v2/log.py
+++ b/otcextensions/sdk/function_graph/v2/log.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack import resource
+from openstack import exceptions
+
+
+class Log(resource.Resource):
+    base_path = '/fgs/functions/%(function_urn)s/lts-log-detail'
+    # Capabilities
+    allow_create = True
+    allow_fetch = True
+
+    # Properties
+    function_urn = resource.URI('function_urn', type=str)
+
+    # Attributes
+    #: Log group name.
+    group_name = resource.Body('group_name', type=str)
+    #: Log group ID.
+    group_id = resource.Body('group_id', type=str)
+    #: Log stream ID.
+    stream_id = resource.Body('stream_id', type=str)
+    #: Log stream name.
+    stream_name = resource.Body('stream_name', type=str)

--- a/otcextensions/sdk/function_graph/v2/log.py
+++ b/otcextensions/sdk/function_graph/v2/log.py
@@ -11,7 +11,6 @@
 # under the License.
 
 from openstack import resource
-from openstack import exceptions
 
 
 class Log(resource.Resource):

--- a/otcextensions/sdk/function_graph/v2/template.py
+++ b/otcextensions/sdk/function_graph/v2/template.py
@@ -1,0 +1,75 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack import resource
+from openstack import exceptions
+
+
+class TriggerMetadataList(resource.Resource):
+    trigger_name = resource.Body('trigger_name', type=str)
+    trigger_type = resource.Body('trigger_type', type=str)
+    event_type = resource.Body('event_type', type=str)
+    event_data = resource.Body('event_data', type=str)
+
+
+class TempDetail(resource.Resource):
+    input = resource.Body('input', type=str)
+    output = resource.Body('output', type=str)
+    warning = resource.Body('warning', type=str)
+
+
+class Template(resource.Resource):
+    base_path = 'fgs/templates/%(template_id)s'
+    # Capabilities
+    allow_fetch = True
+    # Properties
+    template_id = resource.URI('template_id', type=str)
+
+    # Attributes
+    #: Template ID.
+    id = resource.Body('id', type=str)
+    #: Template type.
+    type = resource.Body('type', type=int)
+    #: Template title.
+    title = resource.Body('title', type=str)
+    #: Template name.
+    template_name = resource.Body('template_name', type=str)
+    #: Template description.
+    description = resource.Body('description', type=str)
+    #: Template runtime.
+    runtime = resource.Body('runtime', type=str)
+    #: Template handler.
+    handler = resource.Body('handler', type=str)
+    #: Code type.
+    code_type = resource.Body('code_type', type=str)
+    #: Code file.
+    code = resource.Body('code', type=str)
+    #: Maximum duration the function can be executed.
+    #: Value range: 3s-259,200s.
+    timeout = resource.Body('timeout', type=int)
+    #: Memory size.
+    memory_size = resource.Body('memory_size', type=int)
+    #: Trigger information.
+    trigger_metadata_list = resource.Body(
+        'trigger_metadata_list', type=list, list_type=TriggerMetadataList)
+    #: Template details.
+    temp_detail = resource.Body('temp_detail', type=TempDetail)
+    #: User data.
+    user_data = resource.Body('user_data', type=str)
+    #: Encrypted user data.
+    encrypted_user_data = resource.Body('encrypted_user_data', type=str)
+    #: Dependencies required by the template.
+    dependencies = resource.Body('dependencies', type=list)
+    #: Template application scenarios.
+    scene = resource.Body('scene', type=str)
+    #: Cloud service associated with the template.
+    service = resource.Body('service', type=str)

--- a/otcextensions/sdk/function_graph/v2/template.py
+++ b/otcextensions/sdk/function_graph/v2/template.py
@@ -11,7 +11,6 @@
 # under the License.
 
 from openstack import resource
-from openstack import exceptions
 
 
 class TriggerMetadataList(resource.Resource):

--- a/otcextensions/tests/functional/sdk/function_graph/v2/test_alias.py
+++ b/otcextensions/tests/functional/sdk/function_graph/v2/test_alias.py
@@ -22,12 +22,12 @@ from otcextensions.tests.functional.sdk.function_graph import TestFg
 _logger = _log.setup_logging('openstack')
 
 
-class TestFunctionEvent(TestFg):
+class TestFunctionAlias(TestFg):
     ID = None
     uuid = uuid.uuid4().hex[:8]
 
     def setUp(self):
-        super(TestFunctionEvent, self).setUp()
+        super(TestFunctionAlias, self).setUp()
         self.function = self.client.create_function(**TestFg.function_attrs)
         assert isinstance(self.function, function.Function)
 

--- a/otcextensions/tests/functional/sdk/function_graph/v2/test_log.py
+++ b/otcextensions/tests/functional/sdk/function_graph/v2/test_log.py
@@ -9,29 +9,32 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from datetime import datetime
+
+from otcextensions.sdk.function_graph.v2 import function
+from otcextensions.sdk.function_graph.v2 import log
 
 from openstack import _log
 
-from otcextensions.sdk.function_graph.v2 import function
 from otcextensions.tests.functional.sdk.function_graph import TestFg
 
 _logger = _log.setup_logging('openstack')
 
 
-class TestFunctionMetric(TestFg):
-    def test_list_metrics(self):
-        m = list(self.client.metrics(filter='monitor_data'))
-        self.assertIsNotNone(len(m[0].duration))
+class TestFunctionLog(TestFg):
 
-    def test_list_func_metrics(self):
-        now = datetime.now().timestamp()
+    def setUp(self):
+        super(TestFunctionLog, self).setUp()
         self.function = self.client.create_function(**TestFg.function_attrs)
         assert isinstance(self.function, function.Function)
+
+        self.log = self.client.enable_lts_log()
+        assert isinstance(self.log, log.Log)
         self.addCleanup(
             self.client.delete_function,
             self.function
         )
-        m = list(self.client.function_metrics(
-            self.function, period=f'{now},{now - 3600}'))
-        self.assertGreaterEqual(1, len(m))
+
+    def test_get_lts_log_details(self):
+        lg = self.client.get_lts_log_settings(
+            self.function)
+        self.assertIsNotNone(lg)

--- a/otcextensions/tests/functional/sdk/function_graph/v2/test_template.py
+++ b/otcextensions/tests/functional/sdk/function_graph/v2/test_template.py
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from otcextensions.tests.functional import base
+
+from openstack import _log
+
+_logger = _log.setup_logging('openstack')
+
+
+class TestFunctionTemplate(base.BaseFunctionalTest):
+    def test_get_template(self):
+        template = self.conn.functiongraph.get_template(
+            template_id="41d5d9ca-cea3-4ba9-b866-e30c46f45f1f"
+        )
+        self.assertIsNotNone(template)

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_log.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_log.py
@@ -1,0 +1,40 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack.tests.unit import base
+
+from otcextensions.sdk.function_graph.v2 import log
+
+
+EXAMPLE = {
+    'group_name': 'group-xxx',
+    'group_id': 'xxx',
+    'stream_id': 'id-xxx',
+    'stream_name': 'xxx'
+}
+
+
+class TestFunctionInvocation(base.TestCase):
+
+    def test_basic(self):
+        sot = log.Log()
+        path = '/fgs/functions/%(function_urn)s/lts-log-detail'
+        self.assertEqual(path, sot.base_path)
+        self.assertTrue(sot.allow_create)
+        self.assertTrue(sot.allow_fetch)
+
+    def test_make_it(self):
+        sot = log.Log(**EXAMPLE)
+        self.assertEqual(EXAMPLE['group_name'], sot.group_name)
+        self.assertEqual(EXAMPLE['group_id'], sot.group_id)
+        self.assertEqual(EXAMPLE['stream_id'], sot.stream_id)
+        self.assertEqual(EXAMPLE['stream_name'], sot.stream_name)

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
@@ -535,6 +535,7 @@ class TestFgLog(TestFgProxy):
             method_kwargs={},
         )
 
+
 class TestFgTemplate(TestFgProxy):
     def test_get_template(self):
         func = _function.Function(

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
@@ -20,6 +20,8 @@ from otcextensions.sdk.function_graph.v2 import event as _event
 from otcextensions.sdk.function_graph.v2 import alias as _alias
 from otcextensions.sdk.function_graph.v2 import version as _version
 from otcextensions.sdk.function_graph.v2 import metric as _metric
+from otcextensions.sdk.function_graph.v2 import log as _log
+from otcextensions.sdk.function_graph.v2 import template as _t
 from openstack.tests.unit import test_proxy_base
 
 
@@ -504,4 +506,50 @@ class TestFgMetric(TestFgProxy):
                 '1596686400000,1596686400000'
             ],
             expected_args=[],
+        )
+
+
+class TestFgLog(TestFgProxy):
+    def test_get_lts_log_settings(self):
+        func = _function.Function(
+            name='test',
+            func_urn='urn:fss:eu-de:45c274f200d2498683982c8741fb76ac:'
+                     'function:default:access-mysql-js-1213-1737554083545:'
+                     'latest'
+        )
+        self.verify_get(
+            self.proxy.get_lts_log_settings,
+            _log.Log,
+            method_args=[
+                func,
+            ],
+            expected_args=[],
+            expected_kwargs={'function_urn': func.func_urn.rpartition(":")[0],
+                             'requires_id': False}
+        )
+
+    def test_enable_lts_log(self):
+        self.verify_create(
+            self.proxy.enable_lts_log,
+            _log.Log,
+            method_kwargs={},
+        )
+
+class TestFgTemplate(TestFgProxy):
+    def test_get_template(self):
+        func = _function.Function(
+            name='test',
+            func_urn='urn:fss:eu-de:45c274f200d2498683982c8741fb76ac:'
+                     'function:default:access-mysql-js-1213-1737554083545:'
+                     'latest'
+        )
+        self.verify_get(
+            self.proxy.get_template,
+            _t.Template,
+            method_args=["41d5d9ca-cea3-4ba9-b866-e30c46f45f1f"],
+            expected_kwargs={
+                "template_id": "41d5d9ca-cea3-4ba9-b866-e30c46f45f1f",
+                "requires_id": False
+            },
+            expected_args=[]
         )

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
@@ -538,12 +538,6 @@ class TestFgLog(TestFgProxy):
 
 class TestFgTemplate(TestFgProxy):
     def test_get_template(self):
-        func = _function.Function(
-            name='test',
-            func_urn='urn:fss:eu-de:45c274f200d2498683982c8741fb76ac:'
-                     'function:default:access-mysql-js-1213-1737554083545:'
-                     'latest'
-        )
         self.verify_get(
             self.proxy.get_template,
             _t.Template,

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_template.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_template.py
@@ -1,0 +1,52 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack.tests.unit import base
+
+from otcextensions.sdk.function_graph.v2 import template
+
+
+EXAMPLE = {
+    "id": "41d5d9ca-cea3-4ba9-b866-e30c46f45f1f",
+    "type": 1,
+    "title": "access-mysql",
+    "template_name": "access-mysql-js-12.13",
+    "runtime": "Node.js12.13",
+    "handler": "index.handler",
+    "code_type": "",
+    "code": "",
+    "timeout": 30,
+    "memory_size": 256,
+    "temp_detail": {
+        "input": "None",
+        "output": "Execution successful: Database query results",
+        "warning": ""
+    },
+    "scene": "basic_function_usage",
+    "service": "FunctionGraph"
+}
+
+
+class TestFunctionInvocation(base.TestCase):
+
+    def test_basic(self):
+        sot = template.Template()
+        path = 'fgs/templates/%(template_id)s'
+        self.assertEqual(path, sot.base_path)
+        self.assertTrue(sot.allow_fetch)
+
+    def test_make_it(self):
+        sot = template.Template(**EXAMPLE)
+        self.assertEqual(EXAMPLE['id'], sot.id)
+        self.assertEqual(EXAMPLE['type'], sot.type)
+        self.assertEqual(EXAMPLE['title'], sot.title)
+        self.assertEqual(EXAMPLE['template_name'], sot.template_name)

--- a/releasenotes/notes/fg-templates-and-logs-b2a8abd26aaa0a16.yaml
+++ b/releasenotes/notes/fg-templates-and-logs-b2a8abd26aaa0a16.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add FGS templates support.
+  - |
+    Add FGS logs support.


### PR DESCRIPTION
Part of https://github.com/opentelekomcloud/python-otcextensions/issues/438
implements: https://docs.otc.t-systems.com/function-graph/api-ref/apis/function_templates/index.html and https://docs.otc.t-systems.com/function-graph/api-ref/apis/function_logs/index.html