### PR TITLE
[Feat] FunctionGraph reserved instances and import/export

### DIFF
--- a/.stestr.blacklist.functional
+++ b/.stestr.blacklist.functional
@@ -39,4 +39,5 @@ otcextensions.tests.functional.sdk.nat.v2.test_cleanup
 otcextensions.tests.functional.sdk.function_graph.v2.test_dependency*
 otcextensions.tests.functional.sdk.function_graph.v2.test_log*
 otcextensions.tests.functional.sdk.function_graph.v2.test_template*
+otcextensions.tests.functional.sdk.function_graph.v2.test_import_export*
 otcextensions.tests.functional.sdk.apig.v2.test_gateway

--- a/doc/source/sdk/guides/function_graph.rst
+++ b/doc/source/sdk/guides/function_graph.rst
@@ -319,3 +319,43 @@ This API is used to query a specified function template.
 
 .. literalinclude:: ../examples/function_graph/get_template.py
    :lines: 16-26
+
+Querying Reserved Instances of a Function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is used to query reserved instances of a function.
+
+.. literalinclude:: ../examples/function_graph/list_reserved_instances_config.py
+   :lines: 16-24
+
+Querying the Number of Reserved Instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is used to query the number of instances reserved for a function.
+
+.. literalinclude:: ../examples/function_graph/list_reserved_instances.py
+   :lines: 16-24
+
+Changing the Number of Reserved Instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This API is used to change the number of reserved instances.
+
+.. literalinclude:: ../examples/function_graph/update_reserved_instances.py
+   :lines: 16-40
+
+Importing a Function
+^^^^^^^^^^^^^^^^^^^^
+
+This API is used to import a function.
+
+.. literalinclude:: ../examples/function_graph/import_function.py
+   :lines: 16-39
+
+Exporting a Function
+^^^^^^^^^^^^^^^^^^^^
+
+This API is used to export a function.
+
+.. literalinclude:: ../examples/function_graph/export_function.py
+   :lines: 16-38

--- a/doc/source/sdk/proxies/function_graph.rst
+++ b/doc/source/sdk/proxies/function_graph.rst
@@ -87,3 +87,26 @@ Templates
 .. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
   :noindex:
   :members: get_template
+
+Reserved Instances
+^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
+  :noindex:
+  :members: update_instances_number, reserved_instances_config,
+            reserved_instances
+
+
+Export
+^^^^^^
+
+.. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
+  :noindex:
+  :members: export_function
+
+Import
+^^^^^^
+
+.. autoclass:: otcextensions.sdk.function_graph.v2._proxy.Proxy
+  :noindex:
+  :members: import_function

--- a/doc/source/sdk/resources/function_graph/index.rst
+++ b/doc/source/sdk/resources/function_graph/index.rst
@@ -14,3 +14,6 @@ FunctionGraph Resources
    v2/metric
    v2/log
    v2/template
+   v2/reserved_instance
+   v2/export
+   v2/import

--- a/doc/source/sdk/resources/function_graph/v2/export.rst
+++ b/doc/source/sdk/resources/function_graph/v2/export.rst
@@ -1,0 +1,13 @@
+otcextensions.sdk.function_graph.v2.export_function
+===================================================
+
+.. automodule:: otcextensions.sdk.function_graph.v2.export_function
+
+The Export Class
+----------------
+
+The ``Export`` class inherits from
+:class:`~otcextensions.sdk.sdk_resource.Resource`.
+
+.. autoclass:: otcextensions.sdk.function_graph.v2.export_function.Export
+   :members:

--- a/doc/source/sdk/resources/function_graph/v2/import.rst
+++ b/doc/source/sdk/resources/function_graph/v2/import.rst
@@ -1,0 +1,13 @@
+otcextensions.sdk.function_graph.v2.import_function
+===================================================
+
+.. automodule:: otcextensions.sdk.function_graph.v2.import_function
+
+The Import Class
+----------------
+
+The ``Import`` class inherits from
+:class:`~otcextensions.sdk.sdk_resource.Resource`.
+
+.. autoclass:: otcextensions.sdk.function_graph.v2.import_function.Import
+   :members:

--- a/doc/source/sdk/resources/function_graph/v2/reserved_instance.rst
+++ b/doc/source/sdk/resources/function_graph/v2/reserved_instance.rst
@@ -1,0 +1,13 @@
+otcextensions.sdk.function_graph.v2.reserved_instance
+=====================================================
+
+.. automodule:: otcextensions.sdk.function_graph.v2.reserved_instance
+
+The ReservedInstance Class
+--------------------------
+
+The ``ReservedInstance`` class inherits from
+:class:`~otcextensions.sdk.sdk_resource.Resource`.
+
+.. autoclass:: otcextensions.sdk.function_graph.v2.reserved_instance.ReservedInstance
+   :members:

--- a/examples/function_graph/export_function.py
+++ b/examples/function_graph/export_function.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Export function
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+event_attrs = {
+    'name': 'event-xx',
+    'content': 'eyJrIjoidiJ9'
+}
+func_attrs = {
+    'func_name': 'test-function',
+    'package': 'default',
+    'runtime': 'Python3.9',
+    'handler': 'index.handler',
+    'timeout': 30,
+    'memory_size': 128,
+    'code_type': 'inline',
+}
+fg = conn.functiongraph.create_function(**func_attrs)
+exported = conn.functiongraph.export_function(fg, type="code")
+print(exported)

--- a/examples/function_graph/import_function.py
+++ b/examples/function_graph/import_function.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Import a function
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+attrs = {
+    'func_name': 'test',
+    'file_type': 'zip',
+    'file_name': 'test.zip',
+    'file_code': 'UEsDBBQAAAAIAPBbPFpOs3AMAgEAAEwCAAAGAAAAZGVwLnB5jVHB'
+                 'asMwDL37K4R3iSGMMtglsNNW2HH0B4oXq9SjtY2shJbSf5/tpl5y'
+                 'GFQX23qS3nuWPQZPDD/ROyGEwR3stTMHpAZHdNxC7x3jiVUnIAXT'
+                 '+XbJ8QRfmiIC7xGsCwND6YHGaNaqlhVom3PwVoieD16beCNQYj6O'
+                 'bGrP4wL50Ro0kNtqRch4IzfYox0nsJPtjGExboM8kAMNhDF4F7Fi'
+                 '90QSdKnJHDKy5iG+e4Oyg5fVql3C396cE7CTH9kOTUI6uPxJuMra'
+                 'cp0RFinFvRmOITZ3CZNiPPUYGNblsD6pjoDzr/4sawEk8hRrvjy3'
+                 'D9p5/d/OOs9JNiKnxasHLSzJlfgFUEsBAhQDFAAAAAgA8Fs8Wk6z'
+                 'cAwCAQAATAIAAAYAAAAAAAAAAAAAAKSBAAAAAGRlcC5weVBLBQYA'
+                 'AAAAAQABADQAAAAmAQAAAAA='
+}
+func = conn.functiongraph.import_function(**attrs)
+print(func)

--- a/examples/function_graph/list_reserved_instances.py
+++ b/examples/function_graph/list_reserved_instances.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Get all reserved instances
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+for i in conn.functiongraph.reserved_instances():
+    print(i)

--- a/examples/function_graph/list_reserved_instances_config.py
+++ b/examples/function_graph/list_reserved_instances_config.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Get all reserved instances configs
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+for i in conn.functiongraph.reserved_instances_config():
+    print(i)

--- a/examples/function_graph/update_reserved_instances.py
+++ b/examples/function_graph/update_reserved_instances.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""
+Update reserved instances
+"""
+import openstack
+from otcextensions import sdk
+
+openstack.enable_logging(True)
+conn = openstack.connect(cloud='otc')
+sdk.register_otc_extensions(conn)
+
+func_attrs = {
+    'func_name': 'test-function',
+    'package': 'default',
+    'runtime': 'Python3.9',
+    'handler': 'index.handler',
+    'timeout': 30,
+    'memory_size': 128,
+    'code_type': 'inline',
+}
+fg = conn.functiongraph.create_function(**func_attrs)
+
+attrs = {
+    "count": 2
+}
+instances = conn.functiongraph.update_instances_number(
+    fg,
+    **attrs
+)

--- a/otcextensions/sdk/function_graph/v2/_proxy.py
+++ b/otcextensions/sdk/function_graph/v2/_proxy.py
@@ -22,6 +22,9 @@ from otcextensions.sdk.function_graph.v2 import version as _version
 from otcextensions.sdk.function_graph.v2 import metric as _metric
 from otcextensions.sdk.function_graph.v2 import log as _log
 from otcextensions.sdk.function_graph.v2 import template as _t
+from otcextensions.sdk.function_graph.v2 import reserved_instance as _r
+from otcextensions.sdk.function_graph.v2 import export_function as _export
+from otcextensions.sdk.function_graph.v2 import import_function as _import
 
 
 class Proxy(proxy.Proxy):
@@ -506,4 +509,61 @@ class Proxy(proxy.Proxy):
             _t.Template,
             template_id=template_id,
             requires_id=False
+        )
+
+    # ======== Reserved Instances Methods ========
+
+    def update_instances_number(self, function, **attrs):
+        """Update a number of reserved instances from attributes.
+
+        :param function: The URN or instance of the Function to update
+            event in.
+        :param dict attrs: Keyword arguments to update a reserved instances.
+        :returns: The updated ReservedInstance instance.
+        """
+        function = self._get_resource(_function.Function, function)
+        function_urn = function.func_urn.rpartition(":")[0]
+        return self._update(
+            _r.ReservedInstance, function_urn=function_urn, **attrs
+        )
+
+    def reserved_instances_config(self, **query):
+        """List all reserved instances of a function.
+
+        :returns: A generator of ReservedInstance instances.
+        """
+        base_path = "/fgs/functions/reservedinstanceconfigs"
+        return self._list(_r.ReservedInstance, base_path=base_path, **query)
+
+    def reserved_instances(self, **query):
+        """List all query the number of instances reserved for a function.
+
+        :returns: A generator of ReservedInstance instances.
+        """
+        base_path = "/fgs/functions/reservedinstances"
+        return self._list(_r.ReservedInstance, base_path=base_path, **query)
+
+    # ======== Import/Export Methods ========
+
+    def export_function(self, function, **query):
+        """Export a function.
+
+        :param function: The URN or instance of the Function to export.
+        :returns: instance of :class:
+            `~otcextensions.sdk.function_graph.v2.export_function.Export`
+        """
+        function = self._get_resource(_function.Function, function)
+        export = self._get_resource(_export.Export, "")
+        return export._export(self, function, **query)
+
+    def import_function(self, **attrs):
+        """Import a function.
+
+        :param dict attrs: Keyword arguments to create an Alias.
+        :returns: The Import instance.
+        :rtype: :class:
+            `~otcextensions.sdk.function_graph.v2.import_function.Import`
+        """
+        return self._create(
+            _import.Import, **attrs
         )

--- a/otcextensions/sdk/function_graph/v2/_proxy.py
+++ b/otcextensions/sdk/function_graph/v2/_proxy.py
@@ -559,10 +559,8 @@ class Proxy(proxy.Proxy):
     def import_function(self, **attrs):
         """Import a function.
 
-        :param dict attrs: Keyword arguments to create an Alias.
+        :param dict attrs: Keyword arguments to import Function.
         :returns: The Import instance.
-        :rtype: :class:
-            `~otcextensions.sdk.function_graph.v2.import_function.Import`
         """
         return self._create(
             _import.Import, **attrs

--- a/otcextensions/sdk/function_graph/v2/export_function.py
+++ b/otcextensions/sdk/function_graph/v2/export_function.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import urllib
+
+from openstack import resource
+from openstack import exceptions
+
+
+class Export(resource.Resource):
+    base_path = '/fgs/functions/%(function_urn)s/export'
+
+    # Capabilities
+    allow_fetch = True
+
+    _query_mapping = resource.QueryParameters(
+        'config', 'code', 'type'
+    )
+
+    # Properties
+    function_urn = resource.URI('function_urn', type=str)
+
+    # Attributes
+    file_name = resource.Body('file_name', type=str)
+    code_url = resource.Body('code_url', type=str)
+
+    def _export(self, session, function, **query):
+        """Export a function
+        """
+        query_params = urllib.parse.urlencode(query)
+        urn = function.func_urn.rpartition(":")[0]
+        url = self.base_path % {'function_urn': urn}
+        url += '?' + query_params
+        response = session.get(url)
+        exceptions.raise_from_response(response)
+        self._translate_response(response)
+        return self

--- a/otcextensions/sdk/function_graph/v2/import_function.py
+++ b/otcextensions/sdk/function_graph/v2/import_function.py
@@ -1,0 +1,61 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack import resource
+
+
+class Import(resource.Resource):
+    base_path = '/fgs/functions/import'
+
+    # Capabilities
+    allow_create = True
+
+    # Properties
+    func_name = resource.URI('func_name', type=str)
+    file_name = resource.Body('file_name', type=str)
+    file_type = resource.Body('file_type', type=str)
+    file_code = resource.Body('file_code', type=str)
+    package = resource.Body('package', type=str)
+
+    # Attributes
+    func_urn = resource.Body('func_urn', type=str)
+    domain_id = resource.Body('domain_id', type=str)
+    project_id = resource.Body('namespace', type=str)
+    project_name = resource.Body('project_name', type=str)
+    runtime = resource.Body('runtime', type=str)
+    timeout = resource.Body('timeout', type=int)
+    handler = resource.Body('handler', type=str)
+    memory_size = resource.Body('memory_size', type=int)
+    gpu_memory = resource.Body('gpu_memory', type=int)
+    cpu = resource.Body('cpu', type=int)
+    code_type = resource.Body('code_type', type=str)
+    code_url = resource.Body('code_url', type=str)
+    code_filename = resource.Body('code_filename', type=str)
+    code_size = resource.Body('code_size', type=int)
+    user_data = resource.Body('user_data', type=str)
+    digest = resource.Body('digest', type=str)
+    version = resource.Body('version', type=str)
+    image_name = resource.Body('image_name', type=str)
+    xrole = resource.Body('xrole', type=str)
+    app_xrole = resource.Body('app_xrole', type=str)
+    description = resource.Body('description', type=str)
+    version_description = resource.Body('version_description', type=str)
+    last_modified = resource.Body('last_modified', type=str)
+    func_vpc = resource.Body('func_vpc', type=dict)
+    depend_version_list = resource.Body('depend_version_list', type=list)
+    strategy_config = resource.Body('strategy_config', type=dict)
+    extend_config = resource.Body('extend_config', type=str)
+    initializer_handler = resource.Body('initializer_handler', type=str)
+    initializer_timeout = resource.Body('initializer_timeout', type=int)
+    pre_stop_handler = resource.Body('pre_stop_handler', type=str)
+    pre_stop_timeout = resource.Body('pre_stop_timeout', type=int)
+    enterprise_project_id = resource.Body('enterprise_project_id', type=str)

--- a/otcextensions/sdk/function_graph/v2/reserved_instance.py
+++ b/otcextensions/sdk/function_graph/v2/reserved_instance.py
@@ -24,7 +24,9 @@ class CronConfig(resource.Resource):
 
 
 class TacticsConfig(resource.Resource):
-    cron_configs = resource.Body('cron_configs', type=list, list_type=CronConfig)
+    cron_configs = resource.Body(
+        'cron_configs', type=list, list_type=CronConfig
+    )
 
 
 class ReservedInstance(resource.Resource):

--- a/otcextensions/sdk/function_graph/v2/reserved_instance.py
+++ b/otcextensions/sdk/function_graph/v2/reserved_instance.py
@@ -1,0 +1,148 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import os
+
+from openstack import resource
+from openstack import exceptions
+
+
+class CronConfig(resource.Resource):
+    name = resource.Body('name', type=str)
+    cron = resource.Body('cron', type=str)
+    count = resource.Body('count', type=int)
+    start_time = resource.Body('start_time', type=int)
+    expired_time = resource.Body('expired_time', type=int)
+
+
+class TacticsConfig(resource.Resource):
+    cron_configs = resource.Body('cron_configs', type=list, list_type=CronConfig)
+
+
+class ReservedInstance(resource.Resource):
+    base_path = '/fgs/functions/%(function_urn)s/reservedinstances'
+    requires_id = False
+    _query_mapping = resource.QueryParameters(
+        'marker', 'limit', 'urn'
+    )
+
+    # Capabilities
+    allow_fetch = True
+    allow_list = True
+    allow_commit = True
+
+    # Properties
+    function_urn = resource.URI('function_urn', type=str)
+    #: Number of reserved instances.
+    count = resource.Body('count', type=int)
+    #: Whether to enable the idle mode.
+    idle_mode = resource.Body('idle_mode', type=bool)
+    tactics_config = resource.Body('tactics_config', type=dict)
+
+    # Attributes
+    qualifier_type = resource.Body('qualifier_type', type=str)
+    qualifier_name = resource.Body('qualifier_name', type=str)
+    min_count = resource.Body('min_count', type=int)
+    func_urn = resource.Body('func_urn', type=str)
+
+    @classmethod
+    def list(
+            cls,
+            session,
+            paginated=True,
+            base_path=None,
+            allow_unknown_params=False,
+            *,
+            microversion=None,
+            **params,
+    ):
+        """This method is a generator which yields resource objects.
+
+        This resource object list generator handles pagination and takes query
+        params for response filtering.
+
+        :param session: The session to use for making this request.
+        :type session: :class:`~keystoneauth1.adapter.Adapter`
+        :param bool paginated: ``True`` if a GET to this resource returns
+            a paginated series of responses, or ``False`` if a GET returns only
+            one page of data. **When paginated is False only one page of data
+            will be returned regardless of the API's support of pagination.**
+        :param str base_path: Base part of the URI for listing resources, if
+            different from :data:`~openstack.resource.Resource.base_path`.
+        :param bool allow_unknown_params: ``True`` to accept, but discard
+            unknown query parameters. This allows getting list of 'filters' and
+            passing everything known to the server. ``False`` will result in
+            validation exception when unknown query parameters are passed.
+        :param str microversion: API version to override the negotiated one.
+        :param dict params: These keyword arguments are passed through the
+            :meth:`~openstack.resource.QueryParamter._transpose` method
+            to find if any of them match expected query parameters to be sent
+            in the *params* argument to
+            :meth:`~keystoneauth1.adapter.Adapter.get`. They are additionally
+            checked against the :data:`~openstack.resource.Resource.base_path`
+            format string to see if any path fragments need to be filled in by
+            the contents of this argument.
+            Parameters supported as filters by the server side are passed in
+            the API call, remaining parameters are applied as filters to the
+            retrieved results.
+
+        :return: A generator of :class:`Resource` objects.
+        :raises: :exc:`~openstack.exceptions.MethodNotSupported` if
+            :data:`Resource.allow_list` is not set to ``True``.
+        :raises: :exc:`~openstack.exceptions.InvalidResourceQuery` if query
+            contains invalid params.
+        """
+        if not cls.allow_list:
+            raise exceptions.MethodNotSupported(cls, "list")
+        session = cls._get_session(session)
+        microversion = cls._get_microversion(session, action='list')
+
+        if base_path is None:
+            base_path = cls.base_path
+
+        last_part = os.path.basename(base_path)
+        if last_part == 'reservedinstanceconfigs':
+            cls.resources_key = 'reserved_instances'
+        else:
+            cls.resources_key = 'reservedinstances'
+
+        cls._query_mapping._validate(params, base_path=base_path)
+        query_params = cls._query_mapping._transpose(params, cls)
+        uri = base_path % params
+
+        while uri:
+            # Copy query_params due to weird mock unittest interactions
+            response = session.get(
+                uri,
+                headers={
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'},
+                params=query_params.copy())
+            exceptions.raise_from_response(response)
+
+            data = response.json()
+
+            if cls.resources_key:
+                resources = data[cls.resources_key]
+            else:
+                resources = data
+
+            if not isinstance(resources, list):
+                resources = [resources]
+
+            for raw_resource in resources:
+                value = cls.existing(
+                    microversion=microversion,
+                    connection=session._get_connection(),
+                    **raw_resource)
+                yield value
+
+            return

--- a/otcextensions/tests/functional/sdk/function_graph/v2/test_import_export.py
+++ b/otcextensions/tests/functional/sdk/function_graph/v2/test_import_export.py
@@ -1,0 +1,60 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import uuid
+from otcextensions.sdk.function_graph.v2 import function
+
+from openstack import _log
+
+from otcextensions.tests.functional.sdk.function_graph import TestFg
+
+_logger = _log.setup_logging('openstack')
+
+
+class TestFunctionInstances(TestFg):
+    ID = None
+    uuid = uuid.uuid4().hex[:8]
+
+    def setUp(self):
+        super(TestFunctionInstances, self).setUp()
+        self.function = self.client.create_function(**TestFg.function_attrs)
+        assert isinstance(self.function, function.Function)
+
+        self.addCleanup(
+            self.client.delete_function,
+            self.function
+        )
+
+    def test_export(self):
+        inst = self.client.export_function(self.function, type="code")
+        self.assertIsNotNone(inst.file_name)
+        self.assertIsNotNone(inst.code_url)
+
+    def test_import(self):
+        attrs = {
+            'func_name': 'test',
+            'file_type': 'zip',
+            'file_name': 'test.zip',
+            'file_code': 'UEsDBBQAAAAIAPBbPFpOs3AMAgEAAEwCAAAGAAAAZGVwLnB5jVHB'
+                         'asMwDL37K4R3iSGMMtglsNNW2HH0B4oXq9SjtY2shJbSf5/tpl5y'
+                         'GFQX23qS3nuWPQZPDD/ROyGEwR3stTMHpAZHdNxC7x3jiVUnIAXT'
+                         '+XbJ8QRfmiIC7xGsCwND6YHGaNaqlhVom3PwVoieD16beCNQYj6O'
+                         'bGrP4wL50Ro0kNtqRch4IzfYox0nsJPtjGExboM8kAMNhDF4F7Fi'
+                         '90QSdKnJHDKy5iG+e4Oyg5fVql3C396cE7CTH9kOTUI6uPxJuMra'
+                         'cp0RFinFvRmOITZ3CZNiPPUYGNblsD6pjoDzr/4sawEk8hRrvjy3'
+                         'D9p5/d/OOs9JNiKnxasHLSzJlfgFUEsBAhQDFAAAAAgA8Fs8Wk6z'
+                         'cAwCAQAATAIAAAYAAAAAAAAAAAAAAKSBAAAAAGRlcC5weVBLBQYA'
+                         'AAAAAQABADQAAAAmAQAAAAA='
+        }
+        inst = self.client.import_function(**attrs)
+        self.assertIsNotNone(inst.file_name)
+        self.assertIsNotNone(inst.code_url)

--- a/otcextensions/tests/functional/sdk/function_graph/v2/test_reserved_instances.py
+++ b/otcextensions/tests/functional/sdk/function_graph/v2/test_reserved_instances.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import uuid
+from otcextensions.sdk.function_graph.v2 import function
+
+from openstack import _log
+
+from otcextensions.tests.functional.sdk.function_graph import TestFg
+
+_logger = _log.setup_logging('openstack')
+
+
+class TestFunctionInstances(TestFg):
+    ID = None
+    uuid = uuid.uuid4().hex[:8]
+
+    def setUp(self):
+        super(TestFunctionInstances, self).setUp()
+        self.function = self.client.create_function(**TestFg.function_attrs)
+        assert isinstance(self.function, function.Function)
+
+        attrs = {
+            "count": 2
+        }
+        self.instances = self.client.update_instances_number(
+            self.function,
+            **attrs
+        )
+        assert isinstance(self.function, function.Function)
+
+        self.addCleanup(
+            self.client.delete_function,
+            self.function
+        )
+
+    def test_instances_config(self):
+        inst = list(self.client.reserved_instances_config())
+        self.assertEqual(self.function.func_urn, inst[0].function_urn)
+        self.assertEqual(False, inst[0].idle_mode)
+        self.assertEqual(False, inst[0].idle_mode)
+        self.assertEqual(2, inst[0].min_count)
+        self.assertEqual("version", inst[0].qualifier_type)
+        self.assertEqual("latest", inst[0].qualifier_name)
+
+    def test_instances(self):
+        inst = list(self.client.reserved_instances())
+        self.assertEqual(self.function.func_urn, inst[0].func_urn)
+        self.assertEqual(2, inst[0].count)

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_import_export.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_import_export.py
@@ -1,0 +1,72 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack.tests.unit import base
+
+from otcextensions.sdk.function_graph.v2 import import_function
+from otcextensions.sdk.function_graph.v2 import export_function
+
+EXAMPLE_EXPORT = {
+    'file_name': 'test',
+    'code_url': 'url'
+}
+EXAMPLE_IMPORT = {
+    "func_urn": "urn",
+    "func_name": "test_v1_2",
+    "domain_id": "14ee2e35****a7998b******aa24cabf",
+    "project_name": "{region}",
+    "package": "default",
+    "runtime": "Node.js6.10",
+    "timeout": 3,
+    "handler": "index.handler",
+    "memory_size": 128,
+    "cpu": 300,
+    "code_type": "zip",
+    "code_filename": "index.zip",
+    "code_size": 6709,
+    "digest": "123",
+    "version": "latest",
+    "image_name": "latest-191025153727@zehht",
+    "last_modified": "2019-10-25 15:37:27",
+    "strategy_config": {
+        "concurrency": -1
+    },
+    "enterprise_project_id": "123"
+}
+
+
+class TestFunctionExport(base.TestCase):
+
+    def test_basic(self):
+        sot = export_function.Export()
+        path = '/fgs/functions/%(function_urn)s/export'
+        self.assertEqual(path, sot.base_path)
+        self.assertTrue(sot.allow_fetch)
+
+    def test_make_it(self):
+        sot = export_function.Export(**EXAMPLE_EXPORT)
+        self.assertEqual(EXAMPLE_EXPORT['file_name'], sot.file_name)
+        self.assertEqual(EXAMPLE_EXPORT['code_url'], sot.code_url)
+
+
+class TestFunctionImport(base.TestCase):
+
+    def test_basic(self):
+        sot = import_function.Import()
+        path = '/fgs/functions/import'
+        self.assertEqual(path, sot.base_path)
+        self.assertTrue(sot.allow_create)
+
+    def test_make_it(self):
+        sot = import_function.Import(**EXAMPLE_IMPORT)
+        self.assertEqual(EXAMPLE_IMPORT['func_name'], sot.func_name)
+        self.assertEqual(EXAMPLE_IMPORT['code_type'], sot.code_type)

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
@@ -589,6 +589,7 @@ class TestFgReservedInstances(TestFgProxy):
             expected_args=[],
         )
 
+
 class TestFgImportExport(TestFgProxy):
     def test_import_function(self):
         attrs = {

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_proxy.py
@@ -22,6 +22,8 @@ from otcextensions.sdk.function_graph.v2 import version as _version
 from otcextensions.sdk.function_graph.v2 import metric as _metric
 from otcextensions.sdk.function_graph.v2 import log as _log
 from otcextensions.sdk.function_graph.v2 import template as _t
+from otcextensions.sdk.function_graph.v2 import reserved_instance as _r
+from otcextensions.sdk.function_graph.v2 import import_function as _import
 from openstack.tests.unit import test_proxy_base
 
 
@@ -547,4 +549,75 @@ class TestFgTemplate(TestFgProxy):
                 "requires_id": False
             },
             expected_args=[]
+        )
+
+
+class TestFgReservedInstances(TestFgProxy):
+    def test_update_event(self):
+        func = _function.Function(
+            name='test',
+            func_urn='urn:fss:eu-de:45c274f200d2498683982c8741fb76ac:'
+                     'function:default:access-mysql-js-1213-1737554083545:'
+                     'latest'
+        )
+        self.verify_update(
+            self.proxy.update_instances_number,
+            _r.ReservedInstance,
+            method_args=[func],
+            expected_args=[],
+            expected_kwargs={
+                'function_urn': func.func_urn.rpartition(":")[0],
+                'x': 1,
+                'y': 2,
+                'z': 3
+            }
+        )
+
+    def test_reserved_instances_config(self):
+        self.verify_list(
+            self.proxy.reserved_instances_config,
+            _r.ReservedInstance,
+            method_args=[],
+            expected_args=[],
+        )
+
+    def test_reserved_instances(self):
+        self.verify_list(
+            self.proxy.reserved_instances,
+            _r.ReservedInstance,
+            method_args=[],
+            expected_args=[],
+        )
+
+class TestFgImportExport(TestFgProxy):
+    def test_import_function(self):
+        attrs = {
+            'func_name': 'test',
+            'file_type': 'zip',
+            'file_name': 'test.zip',
+            'file_code': 'UEsDBBQAAAAIAPBbPFpOs3AMAgEAAEwCAAAGAAAAZGVwLnB5jVHB'
+                         'asMwDL37K4R3iSGMMtglsNNW2HH0B4oXq9SjtY2shJbSf5/tpl5y'
+                         'GFQX23qS3nuWPQZPDD/ROyGEwR3stTMHpAZHdNxC7x3jiVUnIAXT'
+                         '+XbJ8QRfmiIC7xGsCwND6YHGaNaqlhVom3PwVoieD16beCNQYj6O'
+                         'bGrP4wL50Ro0kNtqRch4IzfYox0nsJPtjGExboM8kAMNhDF4F7Fi'
+                         '90QSdKnJHDKy5iG+e4Oyg5fVql3C396cE7CTH9kOTUI6uPxJuMra'
+                         'cp0RFinFvRmOITZ3CZNiPPUYGNblsD6pjoDzr/4sawEk8hRrvjy3'
+                         'D9p5/d/OOs9JNiKnxasHLSzJlfgFUEsBAhQDFAAAAAgA8Fs8Wk6z'
+                         'cAwCAQAATAIAAAYAAAAAAAAAAAAAAKSBAAAAAGRlcC5weVBLBQYA'
+                         'AAAAAQABADQAAAAmAQAAAAA='
+        }
+        self.verify_create(
+            self.proxy.import_function,
+            _import.Import,
+            method_kwargs={**attrs}
+        )
+
+    def test_export(self):
+        function = _function.Function(id='test_function')
+        self._verify(
+            'otcextensions.sdk.function_graph.v2.export_function.'
+            'Export._export',
+            self.proxy.export_function,
+            method_args=[function],
+            expected_args=[self.proxy, function]
         )

--- a/otcextensions/tests/unit/sdk/function_graph/v2/test_reserved_instances.py
+++ b/otcextensions/tests/unit/sdk/function_graph/v2/test_reserved_instances.py
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from openstack.tests.unit import base
+
+from otcextensions.sdk.function_graph.v2 import reserved_instance
+
+EXAMPLE = {
+    "count": 1
+}
+
+
+class TestFunctionInstances(base.TestCase):
+
+    def test_basic(self):
+        sot = reserved_instance.ReservedInstance()
+        path = '/fgs/functions/%(function_urn)s/reservedinstances'
+        self.assertEqual(path, sot.base_path)
+        self.assertTrue(sot.allow_list)
+        self.assertTrue(sot.allow_commit)
+
+    def test_make_it(self):
+        sot = reserved_instance.ReservedInstance(**EXAMPLE)
+        self.assertEqual(EXAMPLE['count'], sot.count)


### PR DESCRIPTION
Part of https://github.com/opentelekomcloud/python-otcextensions/issues/438
implements: https://docs.otc.t-systems.com/function-graph/api-ref/apis/reserved_instances/index.html and https://docs.otc.t-systems.com/function-graph/api-ref/apis/function_import_and_export/index.html