### PR TITLE
fix TypeError when updating a vpcep service without --ports

### DIFF
--- a/otcextensions/osclient/vpcep/v1/service.py
+++ b/otcextensions/osclient/vpcep/v1/service.py
@@ -359,16 +359,17 @@ class UpdateService(command.ShowOne):
             val = getattr(parsed_args, arg)
             if val:
                 attrs[arg] = val
-        ports = []
-        for port in parsed_args.ports:
-            ports.append(
-                {
-                    'client_port': int(port['client_port']),
-                    'server_port': int(port['server_port']),
-                    'protocol': port['protocol'],
-                }
-            )
-        attrs['ports'] = ports
+        if parsed_args.ports:
+            ports = []
+            for port in parsed_args.ports:
+                ports.append(
+                    {
+                        'client_port': int(port['client_port']),
+                        'server_port': int(port['server_port']),
+                        'protocol': port['protocol'],
+                    }
+                )
+            attrs['ports'] = ports
         if parsed_args.enable_approval:
             attrs['approval_enabled'] = True
         if parsed_args.disable_approval:


### PR DESCRIPTION
Fix for "'NoneType' object is not iterable" error in osclient/vpcep/v1/service.py when updating a VPC Endpoint Service without "--ports".


Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cliff/app.py", line 410, in run_subcommand
    result = cmd.run(parsed_args)
             ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/osc_lib/command/command.py", line 39, in run
    return super(Command, self).run(parsed_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cliff/display.py", line 115, in run
    column_names, data = self.take_action(parsed_args)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/linux/git/python-otcextensions/otcextensions/osclient/vpcep/v1/service.py", line 49, in new
    obj = func(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/linux/git/python-otcextensions/otcextensions/osclient/vpcep/v1/service.py", line 363, in take_action
    for port in parsed_args.ports:
TypeError: 'NoneType' object is not iterable