### PR TITLE
fix TypeError when segment size exceeds DEFAULT_MAX_FILE_SIZE

### DIFF
--- a/otcextensions/sdk/obs/v1/_proxy.py
+++ b/otcextensions/sdk/obs/v1/_proxy.py
@@ -24,7 +24,7 @@ from otcextensions.sdk.obs.v1 import container as _container
 from otcextensions.sdk.obs.v1 import obj as _obj
 
 DEFAULT_OBJECT_SEGMENT_SIZE = 1073741824  # 1GB
-DEFAULT_MAX_FILE_SIZE = (5 * 1024 * 1024 * 1024 + 2) / 2
+DEFAULT_MAX_FILE_SIZE = int((5 * 1024 * 1024 * 1024 + 2) / 2)
 EXPIRES_ISO8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 SHORT_EXPIRES_ISO8601_FORMAT = '%Y-%m-%d'
 


### PR DESCRIPTION
Fix for "TypeError: 'float' object cannot be interpreted as an integer" in sdk/obs/v1/_proxy.py when the specified segment_size exceeds the DEFAULT_MAX_FILE_SIZE.

The TypeError is caused because DEFAULT_MAX_FILE_SIZE is a float, but should be an int:
```
>>> import otcextensions
>>> otcextensions.sdk.obs.v1._proxy.DEFAULT_MAX_FILE_SIZE
2684354561.0
```

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/lib/linux/git/python-otcextensions/otcextensions/sdk/obs/v1/_proxy.py", line 415, in create_object
    self._upload_large_object(
  File "/var/lib/linux/git/python-otcextensions/otcextensions/sdk/obs/v1/_proxy.py", line 451, in _upload_large_object
    segments = utils._get_file_segments(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/linux/git/python-otcextensions/otcextensions/common/utils.py", line 118, in _get_file_segments
    for (index, offset) in enumerate(range(0, file_size, segment_size)):
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer