### PR TITLE
fix parser errors

### DIFF
--- a/otcextensions/osclient/vlb/v3/listener.py
+++ b/otcextensions/osclient/vlb/v3/listener.py
@@ -656,7 +656,7 @@ class UpdateListener(command.ShowOne):
         )
         parser.add_argument(
             '--http2-enable',
-            type='store_true',
+            action='store_true',
             help=_('Specifies whether to use HTTP/2. This parameter'
                    'is available only for HTTPS listeners. If you configure'
                    'this parameter for other types of listeners, it will not'
@@ -700,7 +700,7 @@ class UpdateListener(command.ShowOne):
         )
         parser.add_argument(
             '--disable-member-retry',
-            action='story_true',
+            action='store_true',
             help=_('Specifies whether to enable health check retries for'
                    'backend servers. This parameter is available only for'
                    'HTTP and HTTPS listeners.')

--- a/otcextensions/osclient/vlb/v3/load_balancer.py
+++ b/otcextensions/osclient/vlb/v3/load_balancer.py
@@ -631,7 +631,7 @@ class UpdateLoadBalancer(command.ShowOne):
                    'about the load balancer.')
         )
         parser.add_argument(
-            'subnet-id',
+            '--subnet-id',
             metavar='<subnet_id>',
             dest='vip_subnet_cidr_id',
             help=_('Specifies the ID of the IPv4 subnet where'


### PR DESCRIPTION
Wrong parameters caused "openstack complete" to fail. Fixed the reason.