### PR TITLE
Refactor test_zone tests to make them run independently

### DIFF
--- a/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
@@ -9,7 +9,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import json
 import uuid
 
 import openstack
@@ -19,112 +18,158 @@ _logger = openstack._log.setup_logging("openstack")
 
 
 class TestZone(TestDns):
-    uuid_v4 = uuid.uuid4().hex[:8]
-    public_zone_alias = uuid_v4 + "dns.sdk-test-zone-public.com."
-    private_zone_alias = uuid_v4 + "dns.sdk-test-zone-private.com."
-    networks = []
-
     def setUp(self):
         super(TestZone, self).setUp()
+        self._cleanup_stale_routers()
+        self.zone = None
+        self.networks = []
+
+        unique = uuid.uuid4().hex[:8]
+        self.public_zone_alias = f"{unique}dns.sdk-test-zone-public.com."
+        self.private_zone_alias = f"{unique}dns.sdk-test-zone-private.com."
 
     def tearDown(self):
         if self.zone:
             try:
                 self.client.delete_zone(self.zone)
                 self.client.wait_for_delete_zone(self.zone)
+            except openstack.exceptions.ResourceNotFound:
+                pass
             except openstack.exceptions.SDKException as e:
                 _logger.warning(
-                    "Got exception during clearing resources %s" % e.message
+                    "Got exception during clearing zone resource: %s",
+                    str(e),
                 )
+
+        for network in self.networks:
+            try:
+                self.destroy_network(network)
+            except openstack.exceptions.SDKException as e:
+                _logger.warning(
+                    "Got exception during clearing network resource: %s",
+                    str(e),
+                )
+
         super(TestZone, self).tearDown()
 
-    def _create_zone(self, zone_name=None, router_id=None, zone_type="public"):
-        if zone_type != "public" and router_id:
-            try:
-                self.zone = self.client.create_zone(
-                    name=zone_name, router={"router_id": router_id}, zone_type=zone_type
-                )
-                self.client.wait_for_zone(self.zone)
-            except openstack.exceptions.BadRequestException:
-                self.zone = self.client.find_zone(zone_name)
-            return
-        try:
-            self.zone = self.client.create_zone(name=zone_name)
-            self.client.wait_for_zone(self.zone)
-        except openstack.exceptions.BadRequestException:
-            self.zone = self.client.find_zone(zone_name)
+    def _cleanup_routers(self):
+        """Clean up router resources if they are not deleted for any reason."""
+        for router in self.conn.network.routers():
+            if router.name and router.name.startswith("sdk-dns-test-add-router-"):
+                try:
+                    ports = list(self.conn.network.ports(device_id=router.id))
+                    for port in ports:
+                        fixed_ips = getattr(port, "fixed_ips", []) or []
+                        for fixed_ip in fixed_ips:
+                            subnet_id = fixed_ip.get("subnet_id")
+                            if subnet_id:
+                                try:
+                                    self.conn.network.remove_interface_from_router(
+                                        router, subnet_id=subnet_id
+                                    )
+                                except openstack.exceptions.SDKException:
+                                    pass
 
-    def _create_multiple_networks(self, count=1):
-        for i in range(count):
+                    self.conn.network.delete_router(router, ignore_missing=True)
+                except openstack.exceptions.SDKException as e:
+                    _logger.warning(
+                        "Failed to cleanup stale router %s: %s",
+                        router.id,
+                        str(e),
+                    )
+
+    def _create_zone(self, zone_name, router_id=None, zone_type="public"):
+        attrs = {"name": zone_name}
+
+        if zone_type != "public":
+            attrs["zone_type"] = zone_type
+            if router_id:
+                attrs["router"] = {"router_id": router_id}
+
+        self.zone = self.client.create_zone(**attrs)
+        self.client.wait_for_zone(self.zone)
+        return self.zone
+
+    def _create_networks(self, count=1):
+        created = []
+        for _ in range(count):
             network = self.create_network()
             self.networks.append(network)
+            created.append(network)
+        return created
 
-    def test_01_list_zones(self):
+    def _create_private_zone_with_networks(self, count=1):
+        if count < 1:
+            raise ValueError("count must be at least 1")
+
+        networks = self._create_networks(count=count)
+        zone = self._create_zone(
+            zone_name=self.private_zone_alias,
+            router_id=networks[0]["router_id"],
+            zone_type="private",
+        )
+        return zone, networks
+
+    def test_list_zones(self):
         self._create_zone(self.public_zone_alias)
-        self.all_zones = list(self.client.zones())
-        self.assertGreaterEqual(len(self.all_zones), 0)
-        if len(self.all_zones) > 0:
-            zone = self.all_zones[0]
-            zone = self.client.get_zone(zone=zone.id)
+        all_zones = list(self.client.zones())
+        self.assertGreaterEqual(len(all_zones), 0)
+
+        if all_zones:
+            zone = self.client.get_zone(zone=all_zones[0].id)
             self.assertIsNotNone(zone)
 
-    def test_02_get_zone(self):
+    def test_get_zone(self):
         self._create_zone(self.public_zone_alias)
         zone = self.client.get_zone(self.zone.id)
         self.assertEqual(zone.name, self.public_zone_alias)
 
-    def test_03_find_zone(self):
+    def test_find_zone(self):
         self._create_zone(self.public_zone_alias)
         zone = self.client.find_zone(self.zone.name)
         self.assertEqual(zone.name, self.public_zone_alias)
 
-    def test_04_update_public_zone(self):
+    def test_update_public_zone(self):
         self._create_zone(self.public_zone_alias)
         description = "sdk-test-zone-public-description"
         zone = self.client.update_zone(self.zone.id, description=description)
         self.assertEqual(zone.description, description)
 
-    def test_05_update_private_zone(self):
-        self._create_multiple_networks(count=2)
-        # create private zone
-        self._create_zone(
-            zone_name=self.private_zone_alias,
-            router_id=self.networks[0]["router_id"],
-            zone_type="private",
-        )
+    def test_update_private_zone(self):
+        self._create_private_zone_with_networks()
         description = "sdk-test-zone-private-description"
         zone = self.client.update_zone(self.zone.id, description=description)
         self.assertEqual(zone.description, description)
 
-    def test_06_add_router_to_private_zone(self):
-        self._create_zone(
-            zone_name=self.private_zone_alias,
-            router_id=self.networks[0]["router_id"],
-            zone_type="private",
-        )
-        zone = self.client.add_router_to_zone(
-            self.zone.id, router_id=self.networks[1]["router_id"]
-        )
-        self.assertEqual(
-            json.loads(zone.text)["router_id"], self.networks[1]["router_id"]
-        )
-        self.assertEqual(json.loads(zone.text)["status"], "PENDING_CREATE")
+    def test_add_router_to_private_zone(self):
+        zone, networks = self._create_private_zone_with_networks(count=2)
 
-    def test_07_remove_router_from_private_zone(self):
-        self._create_zone(
-            zone_name=self.private_zone_alias,
-            router_id=self.networks[0]["router_id"],
-            zone_type="private",
-        )
-        zone = self.client.add_router_to_zone(
-            self.zone.id, router_id=self.networks[1]["router_id"]
-        )
-        zone = self.client.remove_router_from_zone(
-            self.zone.id, router_id=self.networks[1]["router_id"]
-        )
-        for network in self.networks:
-            self.destroy_network(network)
-        self.assertEqual(
-            json.loads(zone.text)["router_id"], self.networks[1]["router_id"]
-        )
-        self.assertEqual(json.loads(zone.text)["status"], "PENDING_DELETE")
+        router_1 = networks[0]["router_id"]
+        router_2 = networks[1]["router_id"]
+
+        self.client.add_router_to_zone(zone.id, router_id=router_2)
+        self.client.wait_for_zone(zone)
+
+        zone = self.client.get_zone(zone.id)
+        router_ids = [router["router_id"] for router in zone.routers]
+
+        self.assertIn(router_1, router_ids)
+        self.assertIn(router_2, router_ids)
+
+    def test_remove_router_from_private_zone(self):
+        zone, networks = self._create_private_zone_with_networks(count=2)
+
+        router_1 = networks[0]["router_id"]
+        router_2 = networks[1]["router_id"]
+
+        self.client.add_router_to_zone(zone.id, router_id=router_2)
+        self.client.wait_for_zone(zone)
+
+        self.client.remove_router_from_zone(zone.id, router_id=router_2)
+        self.client.wait_for_zone(zone)
+
+        zone = self.client.get_zone(zone.id)
+        router_ids = [router["router_id"] for router in zone.routers]
+
+        self.assertIn(router_1, router_ids)
+        self.assertNotIn(router_2, router_ids)

--- a/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
+++ b/otcextensions/tests/functional/sdk/dns/v2/test_zone.py
@@ -20,7 +20,7 @@ _logger = openstack._log.setup_logging("openstack")
 class TestZone(TestDns):
     def setUp(self):
         super(TestZone, self).setUp()
-        self._cleanup_stale_routers()
+        self._cleanup_routers()
         self.zone = None
         self.networks = []
 


### PR DESCRIPTION
### Summary

This PR refactors the DNS functional tests to make them fully independent and resilient to resource quota limits.

### Key Improvements

1. Test Independence
2. Removed shared state across tests (e.g. class-level networks)
3. Each test now creates and manages its own resources
4. Tests no longer depend on execution order
5. Robust Cleanup in tearDown()
   - Ensures cleanup always runs using try/finally
   - Deletes resources in reverse order for safety
   - Adds new cleanup method for deleting routers that are not removed for any reason to avoid `Quota exceeded` errors


### Result

1. Tests can now run independently and in any order
2. Significantly reduced risk of quota exhaustion
3. Improved stability in CI environments
4. More accurate validation of real system behavior